### PR TITLE
Switch from wget to http client download method

### DIFF
--- a/plugins/SpotifyPanel/scripts/SpotifyPanel.gd
+++ b/plugins/SpotifyPanel/scripts/SpotifyPanel.gd
@@ -3,6 +3,11 @@ extends Control
 # Plugin
 const PLUGIN_NAME = "SpotifyPanel"
 
+# Downloader
+const DOWNLOADER = preload("res://scripts/helper/downloader.gd")
+# DOWNLOADER instance
+var downloader: DOWNLOADER
+
 # Metadata refresh timer
 var METADATA_REFRESH := 1.0 # state_refresh needs to be not evenly divisible by this
 var metadata_delta := 1.0
@@ -410,12 +415,14 @@ func send_command(endpoint, method, no_update=true, body=""):
 # TODO maybe switch to godot download function
 func download_cover():
 	var filename = art_url.right(art_url.find_last("/") + 1) + ".jpeg"
-	var args: PoolStringArray = ["-O", cache_dir_path + "/" + filename]
-# warning-ignore:return_value_discarded
-	args.insert(0, art_url)
-	if OS.execute("wget", args):
-		push_warning("Failed to download cover")
-		return
+
+	# Set up downloader
+	downloader = DOWNLOADER.new()
+
+	# Download and wait for completion
+	downloader.download(art_url, cache_dir_path + "/" + filename)
+	yield(downloader, "download_completed")
+
 	change_cover(filename)
 
 

--- a/scripts/helper/downloader.gd
+++ b/scripts/helper/downloader.gd
@@ -1,0 +1,100 @@
+# This file is mostly from Nolkaloid's godot-yt-dlp plugin
+# All credit to him
+# https://github.com/Nolkaloid/godot-yt-dlp
+
+# warning-ignore-all:return_value_discarded
+extends Reference
+
+signal download_completed
+signal download_failed
+signal download_progress(percentage)
+
+const _headers: Array = [
+	"User-Agent: Mozilla/5.0",
+	"Accept: */*",
+]
+
+func download(url: String, file_path: String = "user://") -> void:
+	# RegEx for parsing the URL
+	var url_regex = RegEx.new()
+	url_regex.compile("^https?:\\/\\/(?<host>[^\\/]+\\.[a-z]{2,})(?<path>(?>\\/.*)*)$")
+
+	var host: String
+	var path: String
+
+	# Validate the URL
+	match url_regex.search(url) as RegExMatch:
+		null:
+			push_error("[downloader] Invalid URL")
+			emit_signal("download_failed")
+			return
+
+		var result:
+			host = result.get_string("host")
+			path = result.get_string("path")
+
+	var http_client := HTTPClient.new()
+
+	if OS.has_feature("editor"):
+		print("[downloader] Connecting to %s" % host)
+	http_client.connect_to_host(host, -1, true)
+
+	# Connection to the host
+	while http_client.get_status() in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_RESOLVING]:
+		http_client.poll()
+		yield(Engine.get_main_loop(), "idle_frame")
+
+	# Handle connection failure
+	if http_client.get_status() != HTTPClient.STATUS_CONNECTED:
+		push_error("[downloader] Connection failed: status=%d" % http_client.get_status())
+		emit_signal("download_failed")
+		return
+
+	if OS.has_feature("editor"):
+		print("[downloader] Requesting resource at %s" % path)
+	http_client.request(HTTPClient.METHOD_GET, path, _headers)
+
+	# Request the resource
+	while http_client.get_status() == HTTPClient.STATUS_REQUESTING:
+		http_client.poll()
+		yield(Engine.get_main_loop(), "idle_frame")
+
+	# Handle the response
+	match http_client.get_response_code():
+		HTTPClient.RESPONSE_FOUND, HTTPClient.RESPONSE_MOVED_PERMANENTLY:
+			var response_headers := http_client.get_response_headers_as_dictionary()
+			download(response_headers["Location"], file_path)
+			return
+
+		HTTPClient.RESPONSE_OK:
+			if OS.has_feature("editor"):
+				print("[downloader] Storing response body into %s" % file_path)
+			yield(_store_body_to_file(http_client, file_path), "completed")
+
+		_:
+			push_error("[downloader] Request failed with code %d" % http_client.get_response_code())
+			emit_signal("download_failed")
+			return
+
+	emit_signal("download_completed")
+
+
+func _store_body_to_file(http_client: HTTPClient, file_path: String) -> void:
+	var file: File = File.new()
+	file.open(file_path, File.WRITE)
+
+	var percentage_loaded: float = 0.0
+
+	while http_client.get_status() == HTTPClient.STATUS_BODY:
+		http_client.poll()
+		file.store_buffer(http_client.read_response_body_chunk())
+
+		var new_percentage := file.get_len() / float(http_client.get_response_body_length())
+
+		if percentage_loaded < new_percentage:
+			percentage_loaded = new_percentage
+			emit_signal("download_progress", percentage_loaded)
+
+		yield(Engine.get_main_loop(), "idle_frame")
+
+	file.close()


### PR DESCRIPTION
Previously cover arts from spotify were donwloaded with a call to wget, which is an unnecessary external dependency and also mostly only available on linux.
To remove this dependecy and also improve cross platform support, now the download happens with a godot HTTPclient.