### PR TITLE
Switch local theme resources to global one

### DIFF
--- a/plugins/Macroboard/scenes/AddButton.tscn
+++ b/plugins/Macroboard/scenes/AddButton.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://themes/MainTheme.tres" type="Theme" id=1]
 [ext_resource path="res://resources/Macroboard/plus-line-icon.png" type="Texture" id=2]
 
 [node name="AddButton" type="Button"]
 margin_right = 12.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 150, 150 )
-theme = ExtResource( 1 )
 
 [node name="Icon" type="TextureRect" parent="."]
 anchor_right = 1.0

--- a/plugins/Macroboard/scenes/AppButton.tscn
+++ b/plugins/Macroboard/scenes/AppButton.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://themes/MainTheme.tres" type="Theme" id=1]
 [ext_resource path="res://plugins/Macroboard/scripts/AppButton.gd" type="Script" id=2]
 
 [node name="AppButton" type="Button"]
 margin_right = 12.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 150, 150 )
-theme = ExtResource( 1 )
 script = ExtResource( 2 )
 
 [node name="Icon" type="TextureRect" parent="."]
@@ -29,7 +27,6 @@ margin_left = -60.0
 margin_top = -35.0
 margin_right = 60.0
 margin_bottom = -20.0
-theme = ExtResource( 1 )
 align = 1
 valign = 1
 clip_text = true

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -10,6 +10,7 @@
 [node name="Main" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+theme = ExtResource( 2 )
 
 [node name="VSeparator" type="VBoxContainer" parent="."]
 anchor_right = 1.0
@@ -31,7 +32,6 @@ margin_bottom = 62.0
 rect_min_size = Vector2( 400, 0 )
 size_flags_horizontal = 0
 size_flags_vertical = 4
-theme = ExtResource( 2 )
 text = "Devices"
 align = 1
 script = ExtResource( 3 )


### PR DESCRIPTION
Right now all nodes were themed by using a localresource.
This commit makes it so only the top node "main" is themed with this resource and all child notes inherit this theme.
This should make it easier in the future to switch themes at runtime.