### PR TITLE
Better logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ bin/*
 .godot/
 export.cfg
 
+rust/target
+rust/Cargo.lock
 plugins/Touch/rust/target
 plugins/Touch/rust/Cargo.lock
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifdef GODOT_EXECUTABLE
 	GODOT_VERSION := $(shell $(GODOT_EXECUTABLE) --version 2>/dev/null | cut -d'.' -f1)
 endif
 CARGO := $(shell command -v cargo 2> /dev/null)
-RUST_DIR = plugins/Touch/rust
+RUST_DIRS = rust/ plugins/Touch/rust/
 INSTALL_BIN = /usr/local/bin/
 INSTALL_LIB = /usr/local/lib/
 ICON_DIR = /usr/local/share/icons/hicolor/256x256/apps/
@@ -11,7 +11,8 @@ DESKTOP_DIR = /usr/local/share/applications/
 BUILD_DIR = bin
 DREAMDECK_LINUX = dreamdeck
 DREAMDECK_WINDOWS = dreamdeck.exe
-LIBDREAMDECK = libdreamdeck_touch.so
+LIBDREAMDECKTOUCH = libdreamdeck_touch.so
+LIBDREAMDECK = libdreamdeck.so
 RESOURCE_PATH = resources/
 DREAMDECK_ICON = icons/dreamdeck.png
 DESKTOP_FILE = dreamdeck.desktop
@@ -52,26 +53,29 @@ rust:
 ifndef CARGO
 	$(error "Cargo not installed, rust is required")
 endif
-	cd $(RUST_DIR) && cargo build --release
+	for dir in $(RUST_DIRS); do cargo build --manifest-path $${dir}/Cargo.toml --release; done
 
 clean: rust-clean
 	rm -f $(BUILD_DIR)/$(DREAMDECK_LINUX)
 	rm -f $(BUILD_DIR)/$(DREAMDECK_WINDOWS)
 	rm -f $(BUILD_DIR)/$(LIBDREAMDECK)
+	rm -f $(BUILD_DIR)/$(LIBDREAMDECKTOUCH)
 
 rust-clean:
 ifdef CARGO
-	cd $(RUST_DIR) && cargo clean
+	for dir in $(RUST_DIRS); do cargo clean --manifest-path $${dir}/Cargo.toml; done
 endif
 
 install:
 	install -D bin/$(DREAMDECK_LINUX) $(INSTALL_BIN)$(DREAMDECK_LINUX)
 	install -D bin/$(LIBDREAMDECK) $(INSTALL_LIB)$(LIBDREAMDECK)
+	install -D bin/$(LIBDREAMDECKTOUCH) $(INSTALL_LIB)$(LIBDREAMDECKTOUCH)
 	install -D $(RESOURCE_PATH)$(DREAMDECK_ICON) $(ICON_DIR)$(DREAMDECK_ICON)
 	install -D $(RESOURCE_PATH)$(DESKTOP_FILE) $(DESKTOP_DIR)$(DESKTOP_FILE)
 
 uninstall:
 	rm -f $(INSTALL_BIN)$(DREAMDECK_LINUX)
 	rm -f $(INSTALL_LIB)$(LIBDREAMDECK)
+	rm -f $(INSTALL_LIB)$(LIBDREAMDECKTOUCH)
 	rm -f $(ICON_DIR)$(DREAMDECK_ICON)
 	rm -f $(DESKTOP_DIR)$(DESKTOP_FILE)

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Note: icons need to be stored in the config directory in a `icons/` folder and t
 DreamDeck uses code from some Addons that awesome people made. Huge thanks to these projects:
 * [GodotTPD](https://github.com/deep-entertainment/godottpd)
 * [GODOT YT-DLP](https://github.com/Nolkaloid/godot-yt-dlp)
+* [Better Processes](https://gitlab.com/greenfox/better-processes)

--- a/plugins/Macroboard/scripts/AppButton.gd
+++ b/plugins/Macroboard/scripts/AppButton.gd
@@ -109,7 +109,52 @@ func _on_AppButton_pressed():
 		macroboard.edit_button(self)
 		return
 
-	OS.create_process(app, arguments)
+	if config_loader.get_config()["Debug"]:
+		var process = ProcessNode.new()
+		process.connect("stdout", Callable(self, "_on_process_stdout"))
+		process.connect("stderr", Callable(self, "_on_process_stderr"))
+		process.connect("finished", Callable(self, "_on_process_finished"))
+		process.set("cmd", app)
+		process.set("args", arguments as PackedStringArray)
+		self.add_child(process)
+		var ret = process.start()
+		# Error happened
+		if ret:
+			print_debug_msg(app, arguments, "error occurred: " + ret, "red")
+	else:
+		OS.create_process(app, arguments)
+
+
+func _on_process_stdout(stdout: PackedByteArray, cmd: String, args: PackedStringArray):
+	print_debug_msg(cmd, args, stdout.get_string_from_utf8())
+
+func _on_process_stderr(stderr: PackedByteArray, cmd: String, args: PackedStringArray):
+	print_debug_msg(cmd, args, stderr.get_string_from_utf8(), "yellow")
+
+func _on_process_finished(err_code: int, cmd: String, args: PackedStringArray):
+	if err_code:
+		print_debug_msg(cmd, args, "exited with code: " + str(err_code), "red")
+	else:
+		print_debug_msg(cmd, args, "exited with code: success", "green")
+
+
+## Prints a formatted error msg
+## TODO will probably be replaced in the future by some sort of custom logger
+func print_debug_msg(cmd: String, args: PackedStringArray, msg: String, color_code: String = "white"):
+	# The second color code is there because when msg contains newlines the color delimiter seems to break
+	# and be written as plain text into the output.
+	# To circumvent this we just print a white color again before the delimiter
+	print_rich("[color=" + color_code + "]" + Time.get_datetime_string_from_system() + " \"" + cmd + ("" if args.size() == 0 or args.size() == 1 and args[0] == "" else " " + array_to_string(args)) + "\": " + msg + "[color=white][/color]")
+
+
+## Creates a single [String] from an [Array] of [String]s.
+func array_to_string(array) -> String:
+	var ret = ""
+	for arg in array:
+		ret += arg + " "
+
+	ret = ret.erase(ret.length() - 1, 1)
+	return ret
 
 func save():
 	var save_dict = {

--- a/project.godot
+++ b/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="DreamDeck"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.1")
+run/flush_stdout_on_print=true
 run/low_processor_mode=true
 run/low_processor_mode_sleep_usec=20700
 boot_splash/bg_color=Color(0.141176, 0.141176, 0.141176, 1)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dreamdeck"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }

--- a/rust/DreamDeck.gdextension
+++ b/rust/DreamDeck.gdextension
@@ -1,0 +1,6 @@
+[configuration]
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.1
+
+[libraries]
+linux.x86_64 = "res://rust/target/release/libdreamdeck.so"

--- a/rust/src/better_processes.rs
+++ b/rust/src/better_processes.rs
@@ -1,0 +1,231 @@
+use std::io::{Read, Write};
+use std::process::Stdio;
+use std::process::{Child, Command};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread::{self, JoinHandle};
+
+use godot::engine::Engine;
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(base = Node)]
+pub struct ProcessNode {
+    #[export]
+    pub start_on_ready: bool,
+    #[export]
+    pub cmd: GodotString,
+    #[export]
+    pub args: PackedStringArray,
+
+    raw_process: Option<RawProcess>,
+    #[base]
+    base: Base<Node>,
+}
+
+#[godot_api]
+pub impl NodeVirtual for ProcessNode {
+    fn init(base: Base<Node>) -> Self {
+        Self {
+            start_on_ready: false,
+            cmd: GodotString::from(""),
+            args: PackedStringArray::new(),
+            raw_process: None,
+            base,
+        }
+    }
+    fn ready(&mut self) {
+        if Engine::singleton().is_editor_hint() {
+            return;
+        }
+        if self.start_on_ready {
+            let return_string = self.start();
+            if return_string != "".into() {
+                godot_print!("{}", return_string);
+            }
+        }
+    }
+    fn process(&mut self, _delta: f64) {
+        if let Some(mut raw_process) = self.raw_process.take() {
+            let out = raw_process.read_stdout();
+            if !out.is_empty() {
+                self.base.emit_signal(
+                    "stdout".into(),
+                    &[
+                        PackedByteArray::from_iter(out).to_variant(),
+                        self.cmd.to_variant(),
+                        self.args.to_variant(),
+                    ],
+                );
+            }
+            let err = raw_process.read_stderr();
+            if !err.is_empty() {
+                self.base.emit_signal(
+                    "stderr".into(),
+                    &[
+                        PackedByteArray::from_iter(err).to_variant(),
+                        self.cmd.to_variant(),
+                        self.args.to_variant(),
+                    ],
+                );
+            }
+            self.raw_process = if raw_process.is_running() {
+                Some(raw_process)
+            } else {
+                let a = raw_process.child.wait().unwrap().code().unwrap();
+                self.base.emit_signal(
+                    "finished".into(),
+                    &[
+                        Variant::from(a),
+                        self.cmd.to_variant(),
+                        self.args.to_variant(),
+                    ],
+                );
+                self.queue_free();
+                None
+            };
+        }
+    }
+}
+
+#[godot_api]
+pub impl ProcessNode {
+    #[func]
+    fn start(&mut self) -> GodotString {
+        //start cmd
+        let cmd = self.cmd.to_string();
+        let args: Vec<String> = self
+            .args
+            .to_vec()
+            .iter()
+            .map(|i: &GodotString| i.to_string())
+            .collect();
+        let rp = match RawProcess::new(cmd, args) {
+            Ok(rp) => rp,
+            Err(error) => return error.to_string().into(),
+        };
+        self.raw_process = Some(rp);
+        "".into()
+    }
+
+    #[func]
+    fn write_stdin(&mut self, s: PackedByteArray) {
+        match self.raw_process.take() {
+            Some(rp) => {
+                rp.write(s.to_vec().as_slice());
+                self.raw_process = Some(rp);
+            }
+            _ => {
+                godot_error!("Can't write to closed process!");
+            }
+        }
+    }
+
+    // #[func]
+    // fn qwer(&mut self){
+    // }
+
+    #[signal]
+    fn stdout();
+    #[signal]
+    fn stderr();
+    #[signal]
+    fn finished();
+}
+
+struct RawProcess {
+    stdin_tx: Sender<u8>,
+    stdout_rx: Receiver<u8>,
+    stderr_rx: Receiver<u8>,
+    handle_stdout: JoinHandle<Result<(), String>>,
+    _handle_stderr: JoinHandle<Result<(), String>>,
+    _handle_stdin: JoinHandle<Result<(), String>>,
+    child: Child,
+}
+
+impl RawProcess {
+    fn new(cmd: String, args: Vec<String>) -> Result<Self, std::io::Error> {
+        let (stdout_tx, stdout_rx) = channel();
+        let (stderr_tx, stderr_rx) = channel();
+        let (stdin_tx, stdin_rx) = channel();
+        let mut child = match Command::new(cmd)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(error) => return Err(error),
+        };
+
+        let handle_stdout = {
+            let stdout_tx = stdout_tx.clone();
+            let stdout = child.stdout.take();
+            thread::spawn(move || match stdout {
+                Some(stdout) => {
+                    for i in stdout.bytes() {
+                        let _ = stdout_tx.send(i.unwrap());
+                    }
+                    Ok(())
+                }
+                None => Err("StdOut didn't init correctly".into()),
+            })
+        };
+
+        let handle_stdin = {
+            let stdin = child.stdin.take();
+            thread::spawn(move || {
+                //this maybe needs to migrate to the above scope so we can process the handles correctly
+                let mut a = stdin.unwrap();
+                stdin_rx.iter().for_each(|v| {
+                    let _ = a.write(&[v]);
+                    let _ = a.flush(); //this pipe should throw Vec<Vec<u8>> and flush full Vec<u8> all at once
+                });
+                Ok(())
+            })
+        };
+
+        let stderr = child.stderr.take();
+        let stderr_tx = stderr_tx.clone();
+        let handle_stderr = thread::spawn(move || match stderr {
+            Some(stderr) => {
+                for i in stderr.bytes() {
+                    let _ = stderr_tx.send(i.unwrap());
+                }
+                Ok(())
+            }
+            None => Err("StdErr didn't init correctly".into()),
+        });
+
+        Ok(Self {
+            stdout_rx,
+            stderr_rx,
+            stdin_tx,
+            handle_stdout,
+            _handle_stderr: handle_stderr,
+            _handle_stdin: handle_stdin,
+            child,
+        })
+    }
+    fn write(&self, text: &[u8]) {
+        //should this be a str? u8 array?
+        text.iter().for_each(|i| {
+            let _ = self.stdin_tx.send(*i);
+        })
+    }
+    fn read_stderr(&self) -> Vec<u8> {
+        self.stderr_rx.try_iter().collect()
+    }
+    fn read_stdout(&self) -> Vec<u8> {
+        self.stdout_rx.try_iter().collect()
+    }
+    fn is_running(&self) -> bool {
+        !self.handle_stdout.is_finished()
+    }
+}
+
+impl Drop for RawProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,8 @@
+use godot::prelude::*;
+
+mod better_processes;
+
+struct DreamDeck;
+
+#[gdextension]
+unsafe impl ExtensionLibrary for DreamDeck {}

--- a/scripts/AutoLoad/ConfigLoader.gd
+++ b/scripts/AutoLoad/ConfigLoader.gd
@@ -4,11 +4,12 @@ const DEFAULT_CONFIG := {
 	"Transparent Background": false,
 	"Fullscreen": false,
 	"Hide Mouse Cursor": false,
+	"Debug": false,
 	"Window Size": {
 		"Width": 1280,
 		"Height": 800
+		},
 	}
-}
 
 var conf_dir: String = OS.get_user_data_dir() + "/"
 


### PR DESCRIPTION
This introduces a second method of spawning processes, which can better log
stdout, stderr and exit codes of the process. This method however for now only
gets enabled when in debug mode because it adds a node to the scene tree for
every process which may, when a lot of these are active, have performance
implications.