### PR TITLE
Basic plugin loading at runtime

### DIFF
--- a/scripts/auto_load/plugin_coordinator.gd
+++ b/scripts/auto_load/plugin_coordinator.gd
@@ -31,6 +31,8 @@ func _ready():
 
 
 func discover_plugins():
+	_runtime_load_plugins()
+
 	var discovered_plugins := list_plugins()
 	var new_activated_plugins: Dictionary = activated_plugins.get_config()
 	for plugin in discovered_plugins:
@@ -39,6 +41,22 @@ func discover_plugins():
 			new_activated_plugins[plugin] = false
 
 	activated_plugins.change_config(new_activated_plugins)
+
+
+func _runtime_load_plugins():
+	_migrate_plugin_dir()
+	conf_lib.ensure_dir_exists(conf_dir + "plugins")
+	var file_list = conf_lib.list_files_in_dir(conf_dir + "plugins")
+	for file in file_list:
+		if not ProjectSettings.load_resource_pack(file):
+			push_error("Failed to load plugin %s" % file)
+
+
+# FIXME remove in the future
+func _migrate_plugin_dir():
+	if not DirAccess.dir_exists_absolute(conf_dir + "plugin_configs"):
+		print("Detected old plugin config dir, migrating plugins -> plugin_configs")
+		DirAccess.rename_absolute(conf_dir + "plugins", conf_dir + "plugin_configs")
 
 
 func get_activated_plugins() -> Dictionary:
@@ -147,7 +165,7 @@ func list_plugins() -> Array:
 
 # Has trailing slash
 func plugin_path(plugin_name) -> String:
-	return conf_dir + "plugins/" + plugin_name + "/"
+	return conf_dir + "plugin_configs/" + plugin_name + "/"
 
 
 func get_plugin_loader(plugin_name: String):

--- a/scripts/libraries/conf_lib.gd
+++ b/scripts/libraries/conf_lib.gd
@@ -61,3 +61,22 @@ static func conf_merge(dict1: Dictionary, dict2: Dictionary):
 			dict1[key] = dict2[key]
 		elif typeof(dict1[key]) == TYPE_INT:
 			dict1[key] = int(dict2[key])
+
+
+## Returns an [Array] with a recursive list of files in [param path] with absolute path.[br]
+## Instead of [method DirAccess.get_files_at], that only lists filenames and not absolute path.
+static func list_files_in_dir(path: String) -> Array:
+	var file_list: Array = []
+	var dir = DirAccess.open(path)
+	if dir:
+		dir.list_dir_begin()
+		var file_name = dir.get_next()
+		while file_name != "":
+			if dir.current_is_dir():
+				file_list.append_array(list_files_in_dir(path + "/" + file_name))
+			else:
+				file_list.append(path + "/" + file_name)
+			file_name = dir.get_next()
+	else:
+		push_error("Failed to access %s" % path)
+	return file_list


### PR DESCRIPTION
Includes a small migration from dir `plugins` -> `plugin_configs`, because `plugins` is now used for the loading of plugin archives.

Also for future reference plugins should be created manually because godot currently has no export without dependencies option, so a lot of files that would overwrite other files get included. Maybe we could call `load_resource_pack()` without overwriting.
An archive can be created e.g. like this for the `touch` plugin:
```
zip -r touch.zip plugins/touch/ --exclude 'plugins/touch/rust/*'
zip -ur touch.zip plugins/touch/rust/dreamdeck_touch.gdextension plugins/touch/rust/target/release/libdreamdeck_touch.so
```
Shared libaries need to be included.