### PR TITLE
Migrate to a separate label for Config

### DIFF
--- a/plugins/macroboard/src/buttons/macro_action_button.gd
+++ b/plugins/macroboard/src/buttons/macro_action_button.gd
@@ -32,9 +32,16 @@ func deserialize(dict: Dictionary) -> void:
 		return
 
 	_config.apply_dict(dict)
-	_button_label = dict["Button label"]
-	_icon_path = dict["Icon path"]
-	_show_button_label = dict["Show button label"]
+	# FIXME config label migration, delete in the future
+	if dict.has("Button label"):
+		_button_label = dict["Button label"]
+		_icon_path = dict["Icon path"]
+		_show_button_label = dict["Show button label"]
+	else:
+		_button_label = dict["button_label"]
+		_icon_path = dict["icon_path"]
+		_show_button_label = dict["show_button_label"]
+
 	if dict.has("actions"):
 		_actions = []
 		var dict_actions: Array = dict["actions"]

--- a/plugins/macroboard/src/buttons/macro_button_base.gd
+++ b/plugins/macroboard/src/buttons/macro_button_base.gd
@@ -7,9 +7,9 @@ var _config: Config = Config.new()
 
 
 func _init():
-	_config.add_string("Button label", "")
-	_config.add_string("Icon path", "")
-	_config.add_bool("Show button label", false)
+	_config.add_string("Button label", "button_label", "")
+	_config.add_string("Icon path", "icon_path", "")
+	_config.add_bool("Show button label", "show_button_label", false)
 
 
 func get_macroboard() -> Macroboard:
@@ -173,7 +173,7 @@ class ActionEditor extends HBoxContainer:
 		args_editor.mouse_filter = Control.MOUSE_FILTER_STOP
 		_editor_vbox.add_child(args_editor)
 
-		_blocking_editor = Config.BoolEditor.new(Config.BoolObject.new("Wait to finish", false))
+		_blocking_editor = Config.BoolEditor.new(Config.BoolObject.new("Wait to finish", "blocking", false))
 		_editor_vbox.add_child(_blocking_editor)
 
 		_delete_button.text = "X"

--- a/plugins/macroboard/src/macroboard/macroboard.gd
+++ b/plugins/macroboard/src/macroboard/macroboard.gd
@@ -34,9 +34,9 @@ var _tmp_button_position: int = -1
 
 
 func _init() -> void:
-	config.add_int("Columns", 8)
-	config.add_int("Rows", 3)
-	config.add_bool("Square buttons", false)
+	config.add_int("Columns", "columns", 8)
+	config.add_int("Rows", "rows", 3)
+	config.add_bool("Square buttons", "square_buttons", false)
 
 
 func _ready() -> void:
@@ -89,8 +89,8 @@ func handle_config() -> void:
 	var data: Dictionary = config.get_as_dict()
 
 	# Load button settings
-	_max_buttons = Vector2(data["Columns"], data["Rows"])
-	_keep_buttons_square = data["Square buttons"]
+	_max_buttons = Vector2(data["columns"], data["rows"])
+	_keep_buttons_square = data["square_buttons"]
 
 	# Apply settings
 	_on_size_changed()
@@ -287,3 +287,4 @@ func _on_exited_edit_mode() -> void:
 	_toggle_add_buttons()
 
 	_save_layout()
+	config.save()

--- a/plugins/spotify_panel/scripts/spotify_panel.gd
+++ b/plugins/spotify_panel/scripts/spotify_panel.gd
@@ -101,7 +101,7 @@ var credentials: Config = Config.new()
 
 
 func _init():
-	config.add_float("Refresh Interval", 5.0)
+	config.add_float("Refresh Interval", "refresh_interval", 5.0)
 
 
 func _ready():
@@ -112,8 +112,8 @@ func _ready():
 
 	# Load credentials
 	credentials.set_config_path(conf_dir + "credentials.json")
-	credentials.add_string("refresh_token", "")
-	credentials.add_string("encoded_client", "")
+	credentials.add_string("Refresh token", "refresh_token", "")
+	credentials.add_string("Encoded client", "encoded_client", "")
 	load_credentials()
 
 	# Clear cache dir to not fill the user dir with endless albumarts
@@ -148,10 +148,10 @@ func _physics_process(delta):
 func handle_config():
 	var data: Dictionary = config.get_as_dict()
 
-	metadata_refresh = data["Refresh Interval"]
+	metadata_refresh = data["refresh_interval"]
 	# We don't need to refresh devices as often
 	# Add + 0.1 to offset it a bit to metadata_refresh
-	devices_refresh = data["Refresh Interval"] * 3 + 0.1
+	devices_refresh = metadata_refresh * 3 + 0.1
 
 func load_credentials():
 	# Load plugin config
@@ -524,3 +524,7 @@ func _on_VolumeUpButton_pressed():
 	else:
 		volume_state += 5
 	send_command("/me/player/volume?volume_percent=" + str(volume_state), 3)
+
+
+func _on_exited_edit_mode():
+	config.save()

--- a/plugins/ssh/loader.gd
+++ b/plugins/ssh/loader.gd
@@ -5,8 +5,8 @@ var _exec_config: Config = Config.new()
 
 
 func _init():
-	_exec_config.add_string_array("SSH Client", "", [])
-	_exec_config.add_string("Command", "")
+	_exec_config.add_string_array("SSH Client", "ssh_client", "", [])
+	_exec_config.add_string("Command", "command", "")
 	actions = [PluginCoordinator.PluginActionDefinition.new("Execute SSH command", "exec_on_client", "Execute a command on a SSH client", _exec_config, "SSH", "SSHController")]
 
 	plugin_name = "SSH"
@@ -14,4 +14,4 @@ func _init():
 
 
 func set_client_config(clients: Array[String]) -> void:
-	_exec_config.get_object("SSH Client").set_string_array(clients)
+	_exec_config.get_object("ssh_client").set_string_array(clients)

--- a/plugins/ssh/scripts/ssh_controller.gd
+++ b/plugins/ssh/scripts/ssh_controller.gd
@@ -37,6 +37,9 @@ func _ready():
 		main_menu_button.init("SSH Config", "/" + get_path().get_concatenated_names(), "show_config")
 		get_node("/root/Main/MainMenu").add_custom_button(main_menu_button)
 
+	# FIXME config label migration, delete in the future
+	GlobalSignals.connect("exited_edit_mode", _on_exited_edit_mode)
+
 
 func _process(_delta):
 	# Thread cleanup
@@ -147,3 +150,7 @@ func exec_on_client(client_name: String, cmd: String):
 	var thread := Thread.new()
 	thread.start(ssh_client.exec.bind(cmd))
 	thread_pool.append(thread)
+
+
+func _on_exited_edit_mode() -> void:
+	config.save()

--- a/plugins/touch/scripts/touch_controller.gd
+++ b/plugins/touch/scripts/touch_controller.gd
@@ -25,8 +25,11 @@ var _default_device: String
 
 
 func _init():
-	config.add_string("Default Device", "")
+	config.add_string("Default Device", "default_device", "")
 	plugin_name = PLUGIN_NAME
+
+	# FIXME config label migration, delete in the future
+	GlobalSignals.connect("exited_edit_mode", _on_exited_edit_mode)
 
 
 func _ready():
@@ -58,7 +61,7 @@ func _on_main_window_resized():
 func handle_config():
 	var data = config.get_as_dict()
 
-	_default_device = data["Default Device"]
+	_default_device = data["default_device"]
 
 
 func get_default_device() -> String:
@@ -139,3 +142,7 @@ func handle_event():
 		Input.parse_input_event(mod_event)
 		if OS.has_feature("editor"):
 			get_node("/root/Main/DebugCursor").position = mod_event.position
+
+
+func _on_exited_edit_mode() -> void:
+	config.save()

--- a/scripts/global/config.gd
+++ b/scripts/global/config.gd
@@ -9,8 +9,8 @@ class_name Config
 ##
 ## [codeblock]
 ## config: Config = Config.new()
-## config.add_bool("Example bool", false, "[code]Example code[/code]\n[b]Another line[/b]")
-## config.add_string("Example string", "Example default value")
+## config.add_bool("Example bool", "example_bool", false, "[code]Example code[/code]\n[b]Another line[/b]")
+## config.add_string("Example string", "example string", "Example default value")
 ## [/codeblock]
 
 ## Emitted when the config changed
@@ -41,6 +41,14 @@ func load_config():
 func apply_dict(dict: Dictionary):
 	for item in dict:
 		var object = get_object(item)
+
+		# FIXME temporary migration for config label
+		if not object:
+			for config_object in _config:
+				if config_object.get_label() == item:
+					object = config_object
+					break
+
 		if object:
 			object.set_value(dict[item])
 
@@ -80,60 +88,72 @@ func add_object(object: ConfigObject) -> void:
 
 
 ## Adds a bool object.[br]
-## [param key]: Key string for the object (Will be the label in [Config.ConfigEditor])[br]
+## [param label]: User facing name of this object when editing[br]
+## [param key]: Key string for the object (Will be what it is saved as on disk and also what you
+## get when running [method get_as_dict])[br]
 ## [param value]: Default value[br]
-## [param description](Optional): Description for what this config object does.
-func add_bool(key: String, value: bool, description: String = "") -> void:
-	_config.append(BoolObject.new(key, value, description))
+## [param description](Optional): Description for what this config object does
+func add_bool(label: String, key: String, value: bool, description: String = "") -> void:
+	_config.append(BoolObject.new(label, key, value, description))
 
 
 ## Adds a int object.[br]
-## [param key]: Key string for the object (Will be the label in [Config.ConfigEditor])[br]
+## [param label]: User facing name of this object when editing[br]
+## [param key]: Key string for the object (Will be what it is saved as on disk and also what you
+## get when running [method get_as_dict])[br]
 ## [param value]: Default value[br]
-## [param description](Optional): Description for what this config object does.
-func add_int(key: String, value: int, description: String = "") -> void:
-	_config.append(IntObject.new(key, value, description))
+## [param description](Optional): Description for what this config object does
+func add_int(label: String, key: String, value: int, description: String = "") -> void:
+	_config.append(IntObject.new(label, key, value, description))
 
 
 ## Adds a float object.[br]
-## [param key]: Key string for the object (Will be the label in [Config.ConfigEditor])[br]
+## [param label]: User facing name of this object when editing[br]
+## [param key]: Key string for the object (Will be what it is saved as on disk and also what you
+## get when running [method get_as_dict])[br]
 ## [param value]: Default value[br]
-## [param description](Optional): Description for what this config object does.
-func add_float(key: String, value: float, description: String = "") -> void:
-	_config.append(FloatObject.new(key, value, description))
+## [param description](Optional): Description for what this config object does
+func add_float(label: String, key: String, value: float, description: String = "") -> void:
+	_config.append(FloatObject.new(label, key, value, description))
 
 
 ## Adds a string object.[br]
-## [param key]: Key string for the object (Will be the label in [Config.ConfigEditor])[br]
+## [param label]: User facing name of this object when editing[br]
+## [param key]: Key string for the object (Will be what it is saved as on disk and also what you
+## get when running [method get_as_dict])[br]
 ## [param value]: Default value[br]
-## [param description](Optional): Description for what this config object does.
-func add_string(key: String, value: String, description: String = "") -> void:
-	_config.append(StringObject.new(key, value, description))
+## [param description](Optional): Description for what this config object does
+func add_string(label: String, key: String, value: String, description: String = "") -> void:
+	_config.append(StringObject.new(label, key, value, description))
 
 
 ## Adds a enum object.[br]
-## [param key]: Key string for the object (Will be the label in [Config.ConfigEditor])[br]
+## [param label]: User facing name of this object when editing[br]
+## [param key]: Key string for the object (Will be what it is saved as on disk and also what you
+## get when running [method get_as_dict])[br]
 ## [param value]: Default value[br]
 ## [param enum_dict]: All available values for the enum in a [Dictionary].[br]
 ## Gdscript's [code]enum[/code] automatically generates this enum. See example below.[br]
-## [param description](Optional): Description for what this config object does.[br]
+## [param description](Optional): Description for what this config object does[br]
 ## Example:
 ## [codeblock]
 ## enum Example {ENUM_VALUE1, ENUM_VALUE2}
 ## config.add_enum("Example Enum", Example.ENUM_VALUE1, Example)
 ## [/codeblock]
-func add_enum(key: String, value: int, enum_dict: Dictionary, description: String = "") -> void:
-	_config.append(EnumObject.new(key, value, enum_dict, description))
+func add_enum(label: String, key: String, value: int, enum_dict: Dictionary, description: String = "") -> void:
+	_config.append(EnumObject.new(label, key, value, enum_dict, description))
 
 
 ## Adds a string array object.[br]
 ## This is useful if you want to store a string that can only be predetermined values.
-## [param key]: Key string for the object (Will be the label in [Config.ConfigEditor])[br]
+## [param label]: User facing name of this object when editing[br]
+## [param key]: Key string for the object (Will be what it is saved as on disk and also what you
+## get when running [method get_as_dict])[br]
 ## [param value]: Default value[br]
-## [param string_array]: All available values to pick from.[br]
-## [param description](Optional): Description for what this config object does.[br]
-func add_string_array(key: String, value: String, string_array: Array[String], description: String = "") -> void:
-	_config.append(StringArrayObject.new(key, value, string_array, description))
+## [param string_array]: All available values to pick from[br]
+## [param description](Optional): Description for what this config object does[br]
+func add_string_array(label: String, key: String, value: String, string_array: Array[String], description: String = "") -> void:
+	_config.append(StringArrayObject.new(label, key, value, string_array, description))
 
 
 ## Clears the config of all objects.
@@ -161,39 +181,50 @@ func set_config_path(path: String) -> void:
 
 
 class ConfigObject:
+	var _label: String:
+		get = get_label, set = set_label
 	var _key: String:
 		get = get_key, set = set_key
 	var _description: String:
 		get = get_description, set = set_description
 
 
-	func _init(key: String, description: String = ""):
+	func _init(label: String, key: String, description: String = ""):
+		_label = label
 		_key = key
 		if description != "":
 			_description = description
 
 
-	func get_key():
+	func get_label() -> String:
+		return _label
+
+
+	func set_label(value: String) -> void:
+		_label = value
+
+
+	func get_key() -> String:
 		return _key
 
 
-	func set_key(value):
+	func set_key(value: String) -> void:
 		_key = value
 
 
-	func get_description():
+	func get_description() -> String:
 		return _description
 
 
-	func set_description(value):
+	func set_description(value: String) -> void:
 		_description = value
 
 
-	func get_value():
-		pass
+	func get_value() -> Variant:
+		return null
 
 
-	func set_value(_value):
+	func set_value(_value) -> void:
 		pass
 
 
@@ -206,8 +237,8 @@ class BoolObject extends ConfigObject:
 		set = set_value, get = get_value
 
 
-	func _init(key: String, value: bool, description: String = ""):
-		super(key, description)
+	func _init(label: String, key: String, value: bool, description: String = ""):
+		super(label, key, description)
 		_value = value
 
 
@@ -228,8 +259,8 @@ class IntObject extends ConfigObject:
 		set = set_value, get = get_value
 
 
-	func _init(key: String, value: int, description: String = ""):
-		super(key, description)
+	func _init(label: String, key: String, value: int, description: String = ""):
+		super(label, key, description)
 		_value = value
 
 
@@ -237,7 +268,7 @@ class IntObject extends ConfigObject:
 		return _value
 
 
-	func set_value(value: int):
+	func set_value(value: int) -> void:
 		_value = value
 
 
@@ -250,8 +281,8 @@ class FloatObject extends ConfigObject:
 		set = set_value, get = get_value
 
 
-	func _init(key: String, value: float, description: String = ""):
-		super(key, description)
+	func _init(label: String, key: String, value: float, description: String = ""):
+		super(label, key, description)
 		_value = value
 
 
@@ -272,8 +303,8 @@ class StringObject extends ConfigObject:
 		set = set_value, get = get_value
 
 
-	func _init(key: String, value: String, description: String = ""):
-		super(key, description)
+	func _init(label: String, key: String, value: String, description: String = ""):
+		super(label, key, description)
 		_value = value
 
 
@@ -296,8 +327,8 @@ class EnumObject extends ConfigObject:
 		get = get_enum_dict
 
 
-	func _init(key: String, value: int, enum_dict: Dictionary, description: String = ""):
-		super(key, description)
+	func _init(label: String, key: String, value: int, enum_dict: Dictionary, description: String = ""):
+		super(label, key, description)
 		_value = value
 		_enum_dict = enum_dict
 
@@ -325,8 +356,8 @@ class StringArrayObject extends ConfigObject:
 		set = set_string_array, get = get_string_array
 
 
-	func _init(key: String, value: String, string_array: Array[String], description: String = ""):
-		super(key, description)
+	func _init(label: String, key: String, value: String, string_array: Array[String], description: String = ""):
+		super(label, key, description)
 		_value = value
 		_string_array = string_array
 
@@ -433,17 +464,19 @@ class ConfigEditor extends VBoxContainer:
 
 
 class VariantEditor extends HBoxContainer:
-	var _key_label: Label
+	var _key: String
+	var _name_label: Label = Label.new()
 	var _description_label: RichTextLabel
 
 
 	func _init(object: ConfigObject):
+		_key = object.get_key()
+
 		var vbox: VBoxContainer = VBoxContainer.new()
 		vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
-		_key_label = Label.new()
-		vbox.add_child(_key_label)
-		set_key(object.get_key())
+		vbox.add_child(_name_label)
+		set_label(object.get_label())
 
 		_description_label = RichTextLabel.new()
 		_description_label.fit_content = true
@@ -460,12 +493,12 @@ class VariantEditor extends HBoxContainer:
 		_description_label.text = "[indent]" + description + "[/indent]"
 
 
-	func set_key(value: String):
-		_key_label.text = value
+	func set_label(value: String):
+		_name_label.text = value
 
 
 	func get_key() -> String:
-		return _key_label.text
+		return _key
 
 
 	func set_value(_value):

--- a/src/builtin_actions/dreamdeck_builtin_actions.gd
+++ b/src/builtin_actions/dreamdeck_builtin_actions.gd
@@ -57,17 +57,17 @@ func switch_panel(panel_name: String) -> bool:
 
 func update_available_panels(panels: Array[String]) -> void:
 	_available_panels = panels
-	var panel_object: Config.StringArrayObject = _switch_panel_config.get_object("Panel name")
+	var panel_object: Config.StringArrayObject = _switch_panel_config.get_object("panel_name")
 	if panel_object:
 		panel_object.set_string_array(panels)
 
 
 func _setup_actions() -> void:
 	var exec_cmd_args_config: Config = Config.new()
-	exec_cmd_args_config.add_string("Command", "")
+	exec_cmd_args_config.add_string("Command", "command", "")
 	var timer_args_config: Config = Config.new()
-	timer_args_config.add_float("Time", 1.0)
-	_switch_panel_config.add_string_array("Panel name", "", _available_panels)
+	timer_args_config.add_float("Time", "time", 1.0)
+	_switch_panel_config.add_string_array("Panel name", "panel_name", "", _available_panels)
 
 	_actions = [
 		PluginCoordinator.PluginActionDefinition.new("Execute command", "exec_cmd", "Execute a command on this device", exec_cmd_args_config, "DreamDeck", ""),

--- a/src/layout/layout_panel.gd
+++ b/src/layout/layout_panel.gd
@@ -42,15 +42,25 @@ func remove_plugin_scene(plugin_name: String, scene_name: String):
 
 
 func serialize() -> Dictionary:
-	return {"Plugin": plugin, "Scene": scene, "UUID": uuid, "Panel Name": panel_name}
+	return {"plugin": plugin, "scene": scene, "UUID": uuid, "panel_name": panel_name}
 
 
 func deserialize(config: Dictionary):
+	# FIXME config label migration, delete in the future
+	if config.has("Scene"):
+		uuid = config["UUID"]
+		name = uuid
+		scene = config["Scene"]
+		plugin = config["Plugin"]
+		panel_name = config["Panel Name"]
+		load_scene()
+		return
+
 	uuid = config["UUID"]
 	name = uuid
-	scene = config["Scene"]
-	plugin = config["Plugin"]
-	panel_name = config["Panel Name"]
+	scene = config["scene"]
+	plugin = config["plugin"]
+	panel_name = config["panel_name"]
 
 	load_scene()
 

--- a/src/layout/layout_popup_panel_editor.gd
+++ b/src/layout/layout_popup_panel_editor.gd
@@ -24,9 +24,9 @@ func show_new_panel():
 
 	# Generate a config and the editor for the new panel
 	var new_plugin_config: Config = Config.new()
-	new_plugin_config.add_string("Panel Name", "")
-	new_plugin_config.add_enum("Plugin", -1, PluginCoordinator.generate_plugins_enum())
-	new_plugin_config.add_enum("Scene", -1, {})
+	new_plugin_config.add_string("Panel Name", "panel_name", "")
+	new_plugin_config.add_enum("Plugin", "plugin", -1, PluginCoordinator.generate_plugins_enum())
+	new_plugin_config.add_enum("Scene", "scene", -1, {})
 	_config_editor = new_plugin_config.generate_editor()
 
 	# Connect the plugin enum editor here, because we need to populate
@@ -61,28 +61,28 @@ func _new_panel_save() -> bool:
 	var abort: bool = false
 
 	# Give user feedback on what's missing
-	if new_panel_dict["Panel Name"] == "":
-		_config_editor.get_editor("Panel Name").modulate = Color.RED
+	if new_panel_dict["panel_name"] == "":
+		_config_editor.get_editor("panel_name").modulate = Color.RED
 		abort = true
 	else:
-		_config_editor.get_editor("Panel Name").modulate = Color.WHITE
+		_config_editor.get_editor("panel_name").modulate = Color.WHITE
 
-	if new_panel_dict["Plugin"] == -1:
-		_config_editor.get_editor("Plugin").modulate = Color.RED
+	if new_panel_dict["plugin"] == -1:
+		_config_editor.get_editor("plugin").modulate = Color.RED
 		abort = true
 	else:
-		_config_editor.get_editor("Plugin").modulate = Color.WHITE
+		_config_editor.get_editor("plugin").modulate = Color.WHITE
 
-	if new_panel_dict["Scene"] == -1:
-		_config_editor.get_editor("Scene").modulate = Color.RED
+	if new_panel_dict["scene"] == -1:
+		_config_editor.get_editor("scene").modulate = Color.RED
 		abort = true
 	else:
-		_config_editor.get_editor("Scene").modulate = Color.WHITE
+		_config_editor.get_editor("scene").modulate = Color.WHITE
 
 	if abort: return false
 
 	new_panel_dict["UUID"] = UUID.v4()
-	new_panel_dict["Scene"] = _config_editor.get_editor("Scene").get_value_string()
-	new_panel_dict["Plugin"] = _config_editor.get_editor("Plugin").get_value_string()
+	new_panel_dict["scene"] = _config_editor.get_editor("scene").get_value_string()
+	new_panel_dict["plugin"] = _config_editor.get_editor("plugin").get_value_string()
 	get_node("/root/Main/Layout").add_panel(new_panel_dict)
 	return true

--- a/src/layout/layout_popup_panel_editor.gd
+++ b/src/layout/layout_popup_panel_editor.gd
@@ -31,7 +31,7 @@ func show_new_panel():
 
 	# Connect the plugin enum editor here, because we need to populate
 	# the scene enum with the available scenes from the selected plugin
-	var plugins_editor: Config.EnumEditor = _config_editor.get_editor("Plugin")
+	var plugins_editor: Config.EnumEditor = _config_editor.get_editor("plugin")
 	plugins_editor.get_value_editor().connect("item_selected", _on_new_panel_plugin_selected)
 
 	add_child(_config_editor)
@@ -51,8 +51,8 @@ func _on_new_panel_plugin_selected(idx: int):
 	if idx == -1:
 		return
 
-	var scene_editor: Config.EnumEditor = _config_editor.get_editor("Scene")
-	var plugins_editor: Config.EnumEditor = _config_editor.get_editor("Plugin")
+	var scene_editor: Config.EnumEditor = _config_editor.get_editor("scene")
+	var plugins_editor: Config.EnumEditor = _config_editor.get_editor("plugin")
 	scene_editor.set_enum_dict(PluginCoordinator.generate_scene_enum(plugins_editor.get_value_string()))
 
 

--- a/src/plugins/plugin_controller_base.gd
+++ b/src/plugins/plugin_controller_base.gd
@@ -11,7 +11,7 @@ extends Node
 ##
 ## func _init():
 ##     plugin_name = "Plugin Name"
-##     config.add_bool("Your config setting", false)
+##     config.add_bool("Your config setting", "config_setting", false)
 ##
 ## ...
 ## [/codeblock]

--- a/src/plugins/plugin_loader_base.gd
+++ b/src/plugins/plugin_loader_base.gd
@@ -55,8 +55,8 @@ extends Node
 ## [codeblock]
 ## func _init():
 ##     var _arguments_config: Config = Config.new()
-##     _arguments_config.add_string("Example argument 1", "Default value")
-##     _arguments_config.add_float("Example argument 2", 2.0)
+##     _arguments_config.add_string("Example argument 1", "example_arg1", "Default value")
+##     _arguments_config.add_float("Example argument 2", "example_arg2", 2.0)
 ##     actions = [PluginCoordinator.PluginActionDefinition.new("Example action", "example_func", "A description of what this action does", _arguments_config, "Example plugin", "ExampleController")]
 ## [/codeblock]
 ## The action calls the function in your specified controller and the arguments will be the ones you

--- a/src/plugins/plugin_scene_base.gd
+++ b/src/plugins/plugin_scene_base.gd
@@ -10,7 +10,7 @@ extends Control
 ##
 ##
 ## func _init() -> void:
-##     config.add_bool("Your config setting", false)
+##     config.add_bool("Your config setting", "config_setting", false)
 ##
 ## ...
 ## [/codeblock]


### PR DESCRIPTION
Previously it was pretty annoying that what you wanted to show a user as the name of a config item was also the key it was saved as. Meaning when I wanted to change a user facing label I also needed to do a config migration. To fix this there is now a separate label parameter for all config items.
Includes automatic config migration.