### PR TITLE
Add icon file dialog and rework icon path

### DIFF
--- a/plugins/macroboard/src/buttons/macro_action_button.gd
+++ b/plugins/macroboard/src/buttons/macro_action_button.gd
@@ -1,8 +1,8 @@
 class_name MacroActionButton
 extends MacroButtonBase
 
-var _button_label: String
-var _icon_path: String
+var _button_label: String = ""
+var _icon_path: String = ""
 var _show_button_label: bool = false
 var _actions: Array[PluginCoordinator.PluginAction]
 var _dragging: bool = false # If button is currently being dragged
@@ -22,7 +22,16 @@ func _ready() -> void:
 	offset_right = size.x / 2
 	offset_bottom = size.y / 2
 
+	migrate_icon_path()
+
 	apply_change()
+
+
+# FIXME definitely remove this soon, this migrates the icon path
+func migrate_icon_path() -> void:
+	if _icon_path and not _icon_path.contains("/"):
+		_icon_path = "icons/" + _icon_path
+		_config.get_object("icon_path").set_value(_icon_path)
 
 
 func deserialize(dict: Dictionary) -> void:
@@ -72,10 +81,7 @@ func serialize() -> Dictionary:
 
 
 func apply_change() -> void:
-	if _icon_path:
-		set_image()
-	elif _button_label:
-		text = _button_label
+	set_image()
 
 	if _show_button_label:
 		show_name_with_icon()
@@ -85,9 +91,16 @@ func apply_change() -> void:
 
 func set_image() -> void:
 	if _icon_path:
-		var complete_icon_path: String = ConfigLoader.get_conf_dir() + "icons/" + _icon_path
-		var image: Image = Image.load_from_file(complete_icon_path)
+		var absolute_icon_path: String = _icon_path
+		if not absolute_icon_path.begins_with("/"):
+			absolute_icon_path = ArgumentParser.get_conf_dir() + _icon_path
+		var image: Image = Image.load_from_file(absolute_icon_path)
 		$Icon.texture = ImageTexture.create_from_image(image)
+
+		text = ""
+	else:
+		$Icon.texture = null
+		text = _button_label
 
 
 func show_only_icon() -> void:

--- a/plugins/macroboard/src/buttons/macro_button_base.gd
+++ b/plugins/macroboard/src/buttons/macro_button_base.gd
@@ -14,7 +14,7 @@ var _config: Config = Config.new()
 
 func _init() -> void:
 	_config.add_string("Button label", "button_label", "")
-	_config.add_file_path("Icon path", "icon_path", "", "[i]Can also be relative to config directory[/i]")
+	_config.add_file_path("Icon path", "icon_path", "", "[i]Can also be relative to config directory[/i]", ["*.png,*.jpg,*.jpeg;Supported images", "*;All files"])
 	_config.add_bool("Show button label", "show_button_label", false)
 	_config.add_color("Normal background color", "bg_color", DEFAULT_BG_COLOR, "", false)
 	_config.add_color("Pressed background color", "pressed_color", DEFAULT_PRESSED_COLOR, "", false)

--- a/plugins/macroboard/src/buttons/macro_button_base.gd
+++ b/plugins/macroboard/src/buttons/macro_button_base.gd
@@ -14,7 +14,7 @@ var _config: Config = Config.new()
 
 func _init() -> void:
 	_config.add_string("Button label", "button_label", "")
-	_config.add_string("Icon path", "icon_path", "")
+	_config.add_file_path("Icon path", "icon_path", "", "[i]Can also be relative to config directory[/i]")
 	_config.add_bool("Show button label", "show_button_label", false)
 	_config.add_color("Normal background color", "bg_color", DEFAULT_BG_COLOR, "", false)
 	_config.add_color("Pressed background color", "pressed_color", DEFAULT_PRESSED_COLOR, "", false)

--- a/src/autoload/config_loader.gd
+++ b/src/autoload/config_loader.gd
@@ -42,12 +42,6 @@ func get_config() -> Dictionary:
 	return config.get_as_dict()
 
 
-# Returns the directory of all configs, since this can be modified with arguments
-# the returned path has a "/" at the end
-func get_conf_dir() -> String:
-	return conf_dir
-
-
 func _on_size_changed():
 	if get_window().mode == Window.MODE_FULLSCREEN:
 		return

--- a/src/helper/conf_lib.gd
+++ b/src/helper/conf_lib.gd
@@ -78,3 +78,19 @@ static func list_files_in_dir(path: String) -> Array:
 	else:
 		push_error("Failed to access %s" % path)
 	return file_list
+
+
+## Always returns the absolute path for [param path] and makes sure [param path] is valid.
+## If a path is relative it prefixes it with the current working dir
+## otherwise it just returns the given path.
+static func get_absolute_path(path: String) -> String:
+	if not path.begins_with("/"):
+		var dir = DirAccess.open(path)
+		if not dir:
+			return ""
+		return dir.get_current_dir()
+
+	if not DirAccess.open(path):
+		return ""
+
+	return path

--- a/src/helper/config.gd
+++ b/src/helper/config.gd
@@ -865,16 +865,17 @@ class ColorEditor extends VariantEditor:
 		_reset_to_default_button.texture_normal = RESTORE_DEFAULT_ICON
 		_reset_to_default_button.ignore_texture_size = true
 		_reset_to_default_button.stretch_mode = TextureButton.STRETCH_KEEP_ASPECT_CENTERED
-		_reset_to_default_button.custom_minimum_size = Vector2(25, 0)
+		_reset_to_default_button.custom_minimum_size = Vector2(25, 28)
 		_reset_to_default_button.visible = false
 		_reset_to_default_button.pressed.connect(set_value_color.bind(object.get_default_value()))
 
 		var color_hbox: HBoxContainer = HBoxContainer.new()
 		color_hbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		color_hbox.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 
 		_value_editor = ColorPickerButton.new()
 		_value_editor.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		_value_editor.custom_minimum_size = Vector2(50, 0)
+		_value_editor.custom_minimum_size = Vector2(50, 28)
 		_value_editor.color_changed.connect(_on_color_changed)
 		set_value(object.get_value())
 

--- a/src/helper/config.gd
+++ b/src/helper/config.gd
@@ -952,7 +952,9 @@ class FilePathEditor extends VariantEditor:
 
 	# TODO DisplayServer.file_dialog_show is only implemented on Linux, Windows and MacOS
 	func _on_open_file_dialog_button_pressed() -> void:
-		var initial_path: String = ConfLib.get_absolute_path(ArgumentParser.get_conf_dir() + get_value().get_base_dir())
+		var initial_path: String = get_value().get_base_dir()
+		if not initial_path.begins_with("/"):
+			initial_path = ConfLib.get_absolute_path(ArgumentParser.get_conf_dir() + get_value().get_base_dir())
 
 		DisplayServer.file_dialog_show("Select icon",
 				initial_path,

--- a/src/helper/config.gd
+++ b/src/helper/config.gd
@@ -181,8 +181,9 @@ func add_color(label: String, key: String, default_value: Color, description: St
 ## get when running [method get_as_dict])[br]
 ## [param default_value]: Default value[br]
 ## [param description](Optional): Description for what this config object does[br]
-func add_file_path(label: String, key: String, default_value: String, description: String = "") -> void:
-	_config.append(FilePathObject.new(label, key, default_value, description))
+## [param file_filters](Optional): Specify which file types are supported. See [member FileDialog.filters]
+func add_file_path(label: String, key: String, default_value: String, description: String = "", file_filters: Array[String] = []) -> void:
+	_config.append(FilePathObject.new(label, key, default_value, description, file_filters))
 
 
 ## Clears the config of all objects.
@@ -462,7 +463,12 @@ class ColorObject extends ConfigObject:
 
 
 class FilePathObject extends StringObject:
-	pass
+	var file_filters: Array[String]
+
+
+	func _init(label: String, key: String, default_value: String, description: String = "", init_file_filters: Array[String] = []):
+		super(label, key, default_value, description)
+		file_filters = init_file_filters
 
 
 ## An editor for a [Config]
@@ -909,10 +915,13 @@ class ColorEditor extends VariantEditor:
 
 class FilePathEditor extends VariantEditor:
 	var _value_editor: LineEdit
+	var file_filters: Array[String]
 
 
-	func _init(object: StringObject):
+	func _init(object: FilePathObject):
 		super(object)
+
+		file_filters = object.file_filters
 
 		var editor_hbox: HBoxContainer = HBoxContainer.new()
 		editor_hbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -950,7 +959,7 @@ class FilePathEditor extends VariantEditor:
 				"",
 				true,
 				DisplayServer.FILE_DIALOG_MODE_OPEN_ANY,
-				["*.png,*.jpg,*.jpeg;Supported images", "*;All files"],
+				file_filters,
 				_on_file_dialog_completed)
 
 

--- a/src/helper/config.gd
+++ b/src/helper/config.gd
@@ -915,11 +915,11 @@ class FilePathEditor extends VariantEditor:
 
 		var editor_hbox: HBoxContainer = HBoxContainer.new()
 		editor_hbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		editor_hbox.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		editor_hbox.add_theme_constant_override("separation", 10)
 
 		_value_editor = LineEdit.new()
 		_value_editor.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		_value_editor.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 
 		var open_file_dialog_button: Button = Button.new()
 		open_file_dialog_button.text = "..."
@@ -942,9 +942,7 @@ class FilePathEditor extends VariantEditor:
 
 	# TODO DisplayServer.file_dialog_show is only implemented on Linux, Windows and MacOS
 	func _on_open_file_dialog_button_pressed() -> void:
-		var initial_path: String = ConfLib.get_absolute_path(get_value().get_base_dir())
-		if initial_path == "":
-			initial_path = ConfLib.get_absolute_path(ArgumentParser.get_conf_dir())
+		var initial_path: String = ConfLib.get_absolute_path(ArgumentParser.get_conf_dir() + get_value().get_base_dir())
 
 		DisplayServer.file_dialog_show("Select icon",
 				initial_path,


### PR DESCRIPTION
## Description
Right now the icons can only be inside a `icons` directory inside the config directory.
This PR makes it so icons can be anywhere on the disk. Absolute paths are supported and they can also be relative to the config directory.
The design of the file path editor isn't that great, but changing it only really makes sense when doing the complete design overhaul as introducing a specific theme type for just this probably is unnecessary.
Fixes: #43
## Screenshots
![image](https://github.com/user-attachments/assets/32694c9a-eca0-45f7-8e29-dd6e56fe942d)
![image](https://github.com/user-attachments/assets/471f02ea-7798-4db4-bf5b-4633d2e1319b)
