### PR TITLE
Add backup creation and importing

### DIFF
--- a/plugins/touch/scripts/touch_controller.gd
+++ b/plugins/touch/scripts/touch_controller.gd
@@ -48,7 +48,9 @@ func _ready():
 	handle_config()
 
 	if OS.has_feature("editor"):
-		get_node("/root/Main/DebugCursor").visible = true
+		var debug_cursor: ColorRect = get_node_or_null("/root/Main/DebugCursor")
+		if debug_cursor:
+			debug_cursor.visible = true
 
 
 func _on_main_window_resized():

--- a/src/autoload/config_loader.gd
+++ b/src/autoload/config_loader.gd
@@ -28,13 +28,16 @@ func _ready():
 	config.add_int("Window size width", "window_size_x", 1280)
 	config.add_int("Window size height", "window_size_y", 800)
 
-	# Now that path is set if it is changed we can load
-	config.load_config()
-
-	_handle_config()
+	load_config()
 
 	config.config_changed.connect(_on_config_changed)
 	get_window().connect("size_changed", _on_size_changed)
+
+
+## Loads [member config] from disk and applies it.
+func load_config() -> void:
+	config.load_config()
+	_handle_config()
 
 
 ## Returns the global config data
@@ -70,3 +73,56 @@ func _handle_config():
 func _on_config_changed():
 	config.save()
 	_handle_config()
+
+
+# Creates a zip archive at [param path] of the complete [member conf_dir].
+func _create_config_zip_at(path: String) -> void:
+	var writer: ZIPPacker = ZIPPacker.new()
+	var err: Error = writer.open(path)
+	if err != OK:
+		push_error("Failed to open backup file %s: %s" % [path, err])
+		return
+
+	var files: Array = ConfLib.list_files_in_dir(conf_dir)
+	for file in files:
+		writer.start_file(file.trim_prefix(conf_dir))
+		writer.write_file(FileAccess.get_file_as_bytes(file))
+		var error: Error = FileAccess.get_open_error()
+		if error != OK:
+			push_error("Error when opening file %s: %s" % [file, error])
+		writer.close_file()
+
+	writer.close()
+
+
+# Unpacks a config backup located at [param path] into the [member conf_dir].
+func _unpack_config_backup(path: String) -> void:
+	var reader: ZIPReader = ZIPReader.new()
+	var err: Error = reader.open(path)
+	if err != OK:
+		push_error("Failed to open backup file %s: %s" % [path, err])
+		return
+
+	var files: PackedStringArray = reader.get_files()
+	for file in files:
+		ConfLib.ensure_dir_exists((conf_dir + file).get_base_dir())
+
+		var writer: FileAccess = FileAccess.open(conf_dir + file, FileAccess.WRITE)
+		if not writer:
+			push_error("Failed to write to file %s: %s" % [conf_dir + file, FileAccess.get_open_error()])
+			continue
+
+		writer.store_buffer(reader.read_file(file))
+
+	reader.close()
+
+
+# Completely removes everything inside the [member conf_dir].
+func _remove_config() -> void:
+	var dir: DirAccess = DirAccess.open(conf_dir)
+
+	for file in ConfLib.list_files_in_dir(conf_dir):
+		dir.remove(file.trim_prefix(conf_dir))
+
+	for delete_dir in ConfLib.list_dirs_in_dir(conf_dir):
+		dir.remove(delete_dir.trim_prefix(conf_dir))

--- a/src/autoload/global_signals.gd
+++ b/src/autoload/global_signals.gd
@@ -27,3 +27,12 @@ func exit_edit_mode():
 
 func get_edit_state() -> bool:
 	return edit_state
+
+
+# The purpose for this function is mainly when importing a config backup.
+# It basically completely resets everything and then switches to a new main scene.
+func _perform_complete_reinit() -> void:
+	PluginCoordinator._reinit()
+	ConfigLoader.load_config()
+	var main_scene: PackedScene = load("res://src/main/main.tscn")
+	get_tree().change_scene_to_packed(main_scene)

--- a/src/autoload/plugin_coordinator.gd
+++ b/src/autoload/plugin_coordinator.gd
@@ -21,7 +21,6 @@ func _ready():
 	_conf_path = _conf_dir + FILENAME
 
 	discover_plugins()
-
 	load_activated_plugins()
 
 
@@ -36,7 +35,7 @@ func discover_plugins():
 	if not OS.has_feature("editor"):
 		_runtime_load_plugins()
 
-	var discovered_plugins := list_plugins()
+	var discovered_plugins: Array = list_plugins()
 	for plugin_path in discovered_plugins:
 		var plugin_config: FileAccess = FileAccess.open("res://plugins/%s/plugin.json" % plugin_path,
 			FileAccess.READ)
@@ -116,12 +115,12 @@ func get_cache_dir(plugin_name: String):
 
 
 func list_plugins() -> Array:
-	var files := []
-	var dir = DirAccess.open("res://plugins")
+	var files: Array = []
+	var dir: DirAccess = DirAccess.open("res://plugins")
 	dir.list_dir_begin()
 
 	while true:
-		var file := dir.get_next()
+		var file: String = dir.get_next()
 		if file == "":
 			break
 		elif not file.begins_with("."):
@@ -239,6 +238,22 @@ func add_panel(leaf: DockableLayoutPanel):
 	var panel_editor: PanelEditor = PanelEditor.new()
 	panel_editor.show_new_panel()
 	PopupManager.init_popup(panel_editor, panel_editor.save)
+
+
+# Performs a complete re-initialization.
+func _reinit() -> void:
+	# Remove all plugin loaders
+	for plugin in _plugins:
+		var loader: PluginLoaderBase = plugin.get_loader()
+		if loader:
+			loader.queue_free()
+
+	_plugins = []
+	_scenes = {}
+
+	# Reinit
+	discover_plugins()
+	load_activated_plugins()
 
 
 class Plugin:

--- a/src/builtin_actions/dreamdeck_builtin_actions.gd
+++ b/src/builtin_actions/dreamdeck_builtin_actions.gd
@@ -1,6 +1,6 @@
 extends Node
 
-@onready var _layout: Layout = get_node("/root/Main/Layout")
+var _layout: Layout # Meant to be set by Layout itself
 var _switch_panel_config: Config = Config.new()
 var _available_panels: Array[String] = []
 var _actions: Array[PluginCoordinator.PluginActionDefinition]

--- a/src/helper/conf_lib.gd
+++ b/src/helper/conf_lib.gd
@@ -85,6 +85,30 @@ static func list_files_in_dir(path: String) -> Array[String]:
 	return file_list
 
 
+## Returns an [Array] with a recursive list of directories in [param path] with complete relative path.[br]
+## Instead of [method DirAccess.get_files_at], that only lists filenames and not the complete relative path.
+## The directories are ordered so they can be removed (subdirectories precede their parent).
+static func list_dirs_in_dir(path: String) -> Array[String]:
+	var dir_list: Array[String] = []
+	var dir: DirAccess = DirAccess.open(path)
+	path = path.trim_suffix("/")
+
+	if not dir:
+		push_error("Failed to access %s" % path)
+		return []
+
+	dir.list_dir_begin()
+	var dir_name: String = dir.get_next()
+	while dir_name != "":
+		if dir.current_is_dir():
+			dir_list.append_array(list_dirs_in_dir(path + "/" + dir_name))
+			dir_list.append(path + "/" + dir_name)
+
+		dir_name = dir.get_next()
+
+	return dir_list
+
+
 ## Always returns the absolute path for [param path] and makes sure [param path] is valid.
 ## If a path is relative it prefixes it with the current working dir
 ## otherwise it just returns the given path.

--- a/src/helper/conf_lib.gd
+++ b/src/helper/conf_lib.gd
@@ -61,22 +61,27 @@ static func conf_merge(dict1: Dictionary, dict2: Dictionary):
 			dict1[key] = int(dict2[key])
 
 
-## Returns an [Array] with a recursive list of files in [param path] with absolute path.[br]
-## Instead of [method DirAccess.get_files_at], that only lists filenames and not absolute path.
-static func list_files_in_dir(path: String) -> Array:
-	var file_list: Array = []
-	var dir = DirAccess.open(path)
-	if dir:
-		dir.list_dir_begin()
-		var file_name = dir.get_next()
-		while file_name != "":
-			if dir.current_is_dir():
-				file_list.append_array(list_files_in_dir(path + "/" + file_name))
-			else:
-				file_list.append(path + "/" + file_name)
-			file_name = dir.get_next()
-	else:
+## Returns an [Array] with a recursive list of files in [param path] with complete relative path.[br]
+## Instead of [method DirAccess.get_files_at], that only lists filenames and not the complete relative path.
+static func list_files_in_dir(path: String) -> Array[String]:
+	var file_list: Array[String] = []
+	var dir: DirAccess = DirAccess.open(path)
+	path = path.trim_suffix("/")
+
+	if not dir:
 		push_error("Failed to access %s" % path)
+		return []
+
+	dir.list_dir_begin()
+	var file_name: String = dir.get_next()
+	while file_name != "":
+		if dir.current_is_dir():
+			file_list.append_array(list_files_in_dir(path + "/" + file_name))
+		else:
+			file_list.append(path + "/" + file_name)
+
+		file_name = dir.get_next()
+
 	return file_list
 
 

--- a/src/layout/layout.gd
+++ b/src/layout/layout.gd
@@ -13,6 +13,7 @@ func _ready():
 	super()
 
 	if not load_layout():
+		push_error("Failed to load layout")
 		get_tree().quit(1)
 
 	set_split_handles_visibility(false)
@@ -21,6 +22,8 @@ func _ready():
 
 	GlobalSignals.connect("exited_edit_mode", _on_edit_mode_exited)
 	GlobalSignals.connect("entered_edit_mode", _on_edit_mode_entered)
+
+	DreamdeckBuiltinActions._layout = self
 
 
 func save():
@@ -56,7 +59,9 @@ func load_layout() -> bool:
 
 	# If we are here we have a valid existing configuration, so we can
 	# delete the first time launch helper
-	get_node("/root/Main/FirstTimeLaunch").queue_free()
+	var first_time_launch: Control = get_node_or_null("/root/Main/FirstTimeLaunch")
+	if first_time_launch:
+		first_time_launch.queue_free()
 
 	# Layout setup from config
 	_layout.from_dict(config["Layout"])

--- a/src/main_menu/main_menu.gd
+++ b/src/main_menu/main_menu.gd
@@ -38,8 +38,23 @@ func _ready():
 
 
 func _on_settings_button_pressed() -> void:
+	var settings_vbox: VBoxContainer = VBoxContainer.new()
+	settings_vbox.add_theme_constant_override("separation", 10)
+
 	_settings_popup = ConfigLoader.config.generate_editor()
-	PopupManager.init_popup(_settings_popup, _on_settings_confirmed)
+	_settings_popup.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	settings_vbox.add_child(_settings_popup)
+
+	var backup_button: Button = Button.new()
+	backup_button.text = "Backup config"
+	backup_button.pressed.connect(_on_backup_button_pressed)
+	settings_vbox.add_child(backup_button)
+	var import_button: Button = Button.new()
+	import_button.text = "Import backup"
+	import_button.pressed.connect(_on_import_button_pressed)
+	settings_vbox.add_child(import_button)
+
+	PopupManager.init_popup(settings_vbox, _on_settings_confirmed)
 
 
 func _on_settings_confirmed() -> bool:
@@ -50,3 +65,52 @@ func _on_settings_confirmed() -> bool:
 func _on_plugins_button_pressed() -> void:
 	var plugins_popup: PluginsPopup = plugins_popup_scene.instantiate()
 	PopupManager.init_popup(plugins_popup)
+
+
+func _on_backup_button_pressed() -> void:
+	var file_dialog: FileDialog = _create_backup_file_dialog()
+	file_dialog.file_mode = FileDialog.FILE_MODE_SAVE_FILE
+	file_dialog.title = "Choose backup file"
+	file_dialog.current_file = "backup.zip"
+	file_dialog.show()
+	file_dialog.file_selected.connect(_on_backup_file_dialog_completed)
+
+
+func _on_backup_file_dialog_completed(path: String) -> void:
+	ConfigLoader._create_config_zip_at(path)
+
+
+func _on_import_button_pressed() -> void:
+	var file_dialog: FileDialog = _create_backup_file_dialog()
+	file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
+	file_dialog.title = "Select backup"
+	file_dialog.show()
+	file_dialog.file_selected.connect(_on_import_file_dialog_completed)
+
+
+func _on_import_file_dialog_completed(path: String) -> void:
+	# If FirstTimeLaunch is open there is no config, so no confirmation is required
+	if not get_node_or_null("/root/Main/FirstTimeLaunch"):
+		var confirm_dialog = ConfirmationDialog.new()
+		confirm_dialog.dialog_text = "This will delete the entire current configuration. Are you sure?"
+		PopupManager.get_current_popup().add_child(confirm_dialog)
+		confirm_dialog.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN
+		confirm_dialog.show()
+		confirm_dialog.confirmed.connect(_on_confirm_import.bindv([path]))
+	else:
+		_on_confirm_import(path)
+
+
+func _on_confirm_import(path: String) -> void:
+	ConfigLoader._remove_config()
+	ConfigLoader._unpack_config_backup(path)
+	GlobalSignals._perform_complete_reinit()
+
+
+func _create_backup_file_dialog() -> FileDialog:
+	var file_dialog: FileDialog = FileDialog.new()
+	file_dialog.use_native_dialog = true
+	file_dialog.force_native = true
+	file_dialog.filters = ["*.zip;Zip archive", "*;All files"]
+	PopupManager.get_current_popup().add_child(file_dialog)
+	return file_dialog

--- a/src/plugins/plugin_loader_base.gd
+++ b/src/plugins/plugin_loader_base.gd
@@ -76,7 +76,7 @@ var _controllers: Dictionary = {}
 # Continuous checking if a scene in [member _load_queue] is loaded.
 func _process(_delta):
 	for load_item in _load_queue:
-		var load_status = ResourceLoader.load_threaded_get_status(load_item)
+		var load_status: ResourceLoader.ThreadLoadStatus = ResourceLoader.load_threaded_get_status(load_item)
 		if load_status == ResourceLoader.THREAD_LOAD_LOADED:
 			add_resource(load_item, ResourceLoader.load_threaded_get(load_item))
 		elif load_status == ResourceLoader.THREAD_LOAD_FAILED:


### PR DESCRIPTION
## Description
Adds two new buttons to the settings.
One to create a backup zip archive of the whole current configuration directory.
And another to import a backup zip archive, which then deletes everything in the current configuration directory, unpacks the backup and completely resets the app to apply the new configuration.
## Screenshots
![image](https://github.com/user-attachments/assets/0129c366-b64b-4b2f-bde2-1773a329ac31)
