### PR TITLE
Spotify: Fix resuming from inactive playback

### DIFF
--- a/plugins/spotify_panel/src/spotify_panel.gd
+++ b/plugins/spotify_panel/src/spotify_panel.gd
@@ -376,7 +376,11 @@ func clear_cache():
 func _on_PlayPauseButton_pressed():
 	if not playback_active:
 		play_state = true
-		set_output_device(device_list[$Background/Controls/DeviceOptions.selected], play_state)
+		#set_output_device(device_list[$Background/Controls/DeviceOptions.selected], play_state)
+		# Above api endpoint seems currently broken when trying to transfer playback to a device.
+		# Previously this would work in order to restart the previous playback.
+		# Now it uses the start/resume playback endpoint with a device_id (empty brackets body is for some reason important)
+		send_command("/me/player/play?device_id=%s" % device_list[$Background/Controls/DeviceOptions.selected].id, 3, true, "{}")
 		playback_active = true
 	elif play_state:
 		send_command("/me/player/pause", 3)


### PR DESCRIPTION
Adapt to some changes in the Spotify API. Unsure if this is intentional from their side or a bug, but I'll leave the old code to be able to easily revert this change.