### PR TITLE
Warn user of button deletion when macroboard size changes

### DIFF
--- a/plugins/macroboard/src/buttons/macro_action_button.gd
+++ b/plugins/macroboard/src/buttons/macro_action_button.gd
@@ -1,6 +1,9 @@
 class_name MacroActionButton
 extends MacroButtonBase
 
+## Emitted when a change to this button has happened.
+signal button_changed()
+
 var _button_label: String = ""
 var _icon_path: String = ""
 var _show_button_label: bool = false
@@ -68,6 +71,8 @@ func deserialize(dict: Dictionary) -> void:
 			var action: PluginCoordinator.PluginAction = PluginCoordinator.PluginAction.new()
 			action.deserialize(action_dict)
 			_actions.append(action)
+
+	button_changed.emit()
 
 
 func serialize() -> Dictionary:

--- a/plugins/macroboard/src/buttons/macro_button_base.gd
+++ b/plugins/macroboard/src/buttons/macro_button_base.gd
@@ -1,6 +1,9 @@
 class_name MacroButtonBase
 extends Button
 
+## Emitted when this button is supposed to be deleted.
+signal button_deletion_requested()
+
 const THEME_VARIATION = "MacroButton"
 const DEFAULT_FONT_COLOR = Color(1, 1, 1)
 const DEFAULT_BG_COLOR = Color(1, 1, 1, 0.11)
@@ -21,14 +24,6 @@ func _init() -> void:
 	_config.add_color("Normal font color", "font_color", DEFAULT_FONT_COLOR, "", false)
 	_config.add_color("Pressed font color", "font_pressed_color", DEFAULT_FONT_COLOR, "", false)
 	theme_type_variation = THEME_VARIATION
-
-
-func get_macroboard() -> Macroboard:
-	var macroboard: Variant = get_parent()
-	while not macroboard is Macroboard:
-		macroboard = macroboard.get_parent()
-
-	return macroboard
 
 
 func open_editor(new_button: bool = false) -> void:
@@ -92,9 +87,7 @@ func _on_delete_button_pressed() -> void:
 
 func _on_confirm_deletion() -> void:
 	PopupManager.close_popup()
-	var macroboard: Macroboard = get_macroboard()
-
-	macroboard.call_deferred("delete_button", self)
+	button_deletion_requested.emit()
 
 
 class ActionsEditor extends VBoxContainer:

--- a/plugins/macroboard/src/buttons/macro_no_button.gd
+++ b/plugins/macroboard/src/buttons/macro_no_button.gd
@@ -1,6 +1,9 @@
 class_name MacroNoButton
 extends MacroButtonBase
 
+## Emitted when this button is supposed to be replaced by the [param new_button].
+signal replace_button(caller: MacroNoButton, new_button: MacroButtonBase)
+
 
 func _init() -> void:
 	super()
@@ -33,5 +36,5 @@ func _on_popup_confirmed() -> bool:
 	var new_button: MacroActionButton = load("res://plugins/macroboard/src/buttons/macro_action_button.tscn").instantiate()
 	new_button.deserialize(config)
 
-	get_macroboard().call_deferred("replace_button", self, new_button)
+	replace_button.emit(self, new_button)
 	return true

--- a/plugins/macroboard/src/macroboard/macroboard.gd
+++ b/plugins/macroboard/src/macroboard/macroboard.gd
@@ -32,6 +32,13 @@ var _tmp_button_position: int = -1
 # Path where layout is stored.
 @onready var _layout_path: String = conf_dir + "layout.json"
 
+## WARNING! Should pretty much never be used outside of the [Macroboard] instance itself.[br][br]
+## Signal that gets emitted when confirm dialog gets closed
+## with the bool value representing true if confirmed, otherwise false.[br]
+## This is necessary because awaiting both [ConfirmationDialog] signals,
+## confirmed and canceled is not possible.
+signal _confirm_dialog_closed(bool)
+
 
 func _init() -> void:
 	config.add_int("Columns", "columns", 8)
@@ -95,6 +102,12 @@ func handle_config() -> void:
 	# Apply settings
 	_on_size_changed()
 	_create_buttons(load_layout())
+
+
+## Overwrite confirm function, so it will check for button deletion and ask user.
+func edit_config() -> void:
+	var config_editor: Config.ConfigEditor = config.generate_editor()
+	PopupManager.init_popup([config_editor], _check_apply_and_save_config.bind(config_editor))
 
 
 # Saves layout to disk
@@ -288,3 +301,75 @@ func _on_exited_edit_mode() -> void:
 
 	_save_layout()
 	config.save()
+
+
+# Removes up to [param count] [MacroNoButton]s starting from the back of the layout.[br]
+# [param count] The maximum number of [MacroNoButton]s to remove.[br]
+# Returns true if [param count] [MacroNoButton]s were deleted.
+func _remove_no_buttons(count: int) -> bool:
+	var no_buttons_removed: int = 0
+
+	# Traverse [member _layout_instances] from the back
+	for i in range(_layout_instances.size() - 1, -1, -1):
+		if no_buttons_removed >= count:
+			break
+		if _layout_instances[i] is MacroNoButton:
+			_layout_instances[i].free()
+			_layout_instances.remove_at(i)
+			no_buttons_removed += 1
+
+	return count >= no_buttons_removed
+
+
+# Checks if config changes can be applied without losing any buttons.
+# In case it can't, it shows a deletion warning.
+# If either the deletion warning was confirmed or changes can be applied without losing buttons,
+# it frees as many [MacroNoButton]s as it can/needs to from the scene and also from [member _layout_instances].
+# Returns false if user declined the deletion warning.
+# Note: this only deletes [MacroNoButton]s, it will never delete any other buttons.
+func _on_macroboard_config_change(new_config_dict: Dictionary) -> bool:
+	var new_layout_size: int = new_config_dict["columns"] * new_config_dict["rows"]
+	var max_buttons_diff: int = _layout_instances.size() - new_layout_size
+	# If less max buttons than previously
+	if max_buttons_diff > 0:
+		if _create_layout_array().count(null) < max_buttons_diff:
+			if await _show_button_deletion_warning():
+				_remove_no_buttons(max_buttons_diff)
+				return true
+			else:
+				return false
+
+		else:
+			_remove_no_buttons(max_buttons_diff)
+
+	return true
+
+
+# Shows and returns the value of a [ConfirmationDialog], warning the user of imminent button deletion.
+func _show_button_deletion_warning() -> bool:
+	var confirm_dialog: ConfirmationDialog = ConfirmationDialog.new()
+	confirm_dialog.dialog_text = "WARNING!\nExisting buttons will be deleted by the size change (starting from the back).\nAre you certain you want to continue?"
+	add_child(confirm_dialog)
+	confirm_dialog.initial_position = Window.WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN
+	confirm_dialog.show()
+	confirm_dialog.confirmed.connect(_on_confirm_dialog_confirmed)
+	confirm_dialog.canceled.connect(_on_confirm_dialog_canceled)
+	return await _confirm_dialog_closed
+
+
+func _on_confirm_dialog_confirmed() -> void:
+	_confirm_dialog_closed.emit(true)
+
+
+func _on_confirm_dialog_canceled() -> void:
+	_confirm_dialog_closed.emit(false)
+
+
+# Function for [method Macroboard.edit_config] when popup gets confirmed.
+func _check_apply_and_save_config(config_editor: Config.ConfigEditor) -> void:
+	if await _on_macroboard_config_change(config_editor.serialize()):
+		# Need to save before applying, because it applies from disk
+		# and the deleted [MacroNoButton]s weren't saved before.
+		_save_layout()
+		config_editor.apply()
+		config_editor.save()

--- a/plugins/macroboard/src/macroboard/macroboard.gd
+++ b/plugins/macroboard/src/macroboard/macroboard.gd
@@ -89,6 +89,7 @@ func replace_button(original_button: MacroButtonBase, new_button: MacroButtonBas
 	original_button.free()
 
 	_resize_buttons()
+	_save_layout()
 
 
 ## Load the saved [Macroboard] configuration from disk.
@@ -135,11 +136,17 @@ func _create_buttons(layout: Array) -> void:
 
 			# Only if an entry exists at this position we add it
 			if layout.size() > button_iterator and layout[button_iterator]:
-				new_button = _action_button.instantiate()
-				new_button.deserialize(layout[button_iterator])
+				var action_button: MacroActionButton = _action_button.instantiate()
+				# deserialize before connecting button_changed signal, because it emits button_changed
+				action_button.deserialize(layout[button_iterator])
+				action_button.button_changed.connect(_save_layout)
+				new_button = action_button
 			else:
-				new_button = _no_button.instantiate()
+				var no_button: MacroNoButton = _no_button.instantiate()
+				no_button.replace_button.connect(replace_button, CONNECT_DEFERRED)
+				new_button = no_button
 
+			new_button.button_deletion_requested.connect(delete_button.bind(new_button), CONNECT_DEFERRED)
 			new_button.set_custom_minimum_size(_button_min_size)
 
 			_layout_instances.append(new_button)

--- a/src/autoload/popup_manager.gd
+++ b/src/autoload/popup_manager.gd
@@ -32,7 +32,7 @@ func _process(_delta: float) -> void:
 ## [param cancel_callable] can not be unsuccessful. It also gets called when the popup
 ## is closed.[br]
 func init_popup(scenes: Array[Control],
-	confirm_callable: Callable = func unused() -> bool: return true,
+		confirm_callable: Callable = func unused() -> bool: return true,
 		cancel_callable: Callable = func unused() -> void: pass) -> void:
 	if not scenes:
 		return
@@ -127,12 +127,12 @@ func _create_stack_item(scenes: Array[Control], confirm_callable: Callable, canc
 
 
 func _on_popup_confirmed() -> void:
-	if _popup_stack.back().confirm():
+	if await _popup_stack.back().confirm():
 		pop_stack_item()
 
 
 func _on_popup_cancelled() -> void:
-	_popup_stack.back().cancel()
+	await _popup_stack.back().cancel()
 	pop_stack_item()
 
 
@@ -258,11 +258,11 @@ class StackItem:
 
 
 	func cancel() -> void:
-		cancel_callable.call()
+		await cancel_callable.call()
 
 
 	func confirm() -> bool:
-		var ret_val: Variant = confirm_callable.call()
+		var ret_val: Variant = await confirm_callable.call()
 		if ret_val is bool:
 			return ret_val
 


### PR DESCRIPTION
Introduces a ConfirmationDialog that warns a user if a change to a macroboard's size will delete buttons.
It will first try to delete empty positions but if there are not enough empty positions it asks to user if they are sure that they are okay with deleting existing buttons.
Before size change is applied it also saves the layout, which fixes the problem of button changes being lost when the button amount was changed.

Fixes #31 
Fixes #45 