### PR TITLE
Rework touch plugin to use touch events

### DIFF
--- a/addons/ReorderableContainer/reorderable_container.gd
+++ b/addons/ReorderableContainer/reorderable_container.gd
@@ -88,6 +88,10 @@ var _is_hold := false
 var _current_duration := 0.0
 var _is_using_process := false
 
+# Track global and local mouse position via _gui_input for touch plugin compatibility.
+var _local_mouse_pos: Vector2 = Vector2.ZERO
+var _global_mouse_pos: Vector2 = Vector2.ZERO
+
 
 func _ready():
 	if scroll_container == null and get_parent() is ScrollContainer:
@@ -105,10 +109,13 @@ func _ready():
 
 
 func _gui_input(event):
+	if event is InputEvent:
+		_local_mouse_pos = event.position
+		_global_mouse_pos = get_global_rect().position + _local_mouse_pos
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		for _child in get_children():
 			var child := _child as Control
-			if child.get_rect().has_point(get_local_mouse_position()) and event.is_pressed():
+			if child.get_rect().has_point(event.position) and event.is_pressed():
 				_focus_child = child
 				_is_press = true
 			elif not event.is_pressed():
@@ -180,10 +187,10 @@ func _on_node_added(node):
 
 func _handle_dragging_child_pos(delta):
 	if is_vertical:
-		var target_pos = get_local_mouse_position().y - (_focus_child.size.y / 2.0)
+		var target_pos = _local_mouse_pos.y - (_focus_child.size.y / 2.0)
 		_focus_child.position.y = lerp(_focus_child.position.y, target_pos, delta * speed)
 	else:
-		var target_pos = get_local_mouse_position().x - (_focus_child.size.x / 2.0)
+		var target_pos = _local_mouse_pos.x - (_focus_child.size.x / 2.0)
 		_focus_child.position.x = lerp(_focus_child.position.x, target_pos, delta * speed)
 
 	# Update drop zone index
@@ -198,17 +205,16 @@ func _handle_dragging_child_pos(delta):
 
 
 func _handle_auto_scroll(delta):
-	var mouse_g_pos = get_global_mouse_position()
 	var scroll_g_rect = scroll_container.get_global_rect()
 	if is_vertical:
 		var upper = scroll_g_rect.position.y + (scroll_g_rect.size.y * auto_scroll_range)
 		var lower = scroll_g_rect.position.y + (scroll_g_rect.size.y * (1.0 - auto_scroll_range))
 
-		if upper > mouse_g_pos.y:
-			var factor = (upper - mouse_g_pos.y) / (upper - scroll_g_rect.position.y)
+		if upper > _global_mouse_pos.y:
+			var factor = (upper - _global_mouse_pos.y) / (upper - scroll_g_rect.position.y)
 			scroll_container.scroll_vertical -= delta * float(auto_scroll_speed) * 150.0 * factor
-		elif lower < mouse_g_pos.y:
-			var factor = (mouse_g_pos.y - lower) / (scroll_g_rect.end.y - lower)
+		elif lower < _global_mouse_pos.y:
+			var factor = (_global_mouse_pos.y - lower) / (scroll_g_rect.end.y - lower)
 			scroll_container.scroll_vertical += delta * float(auto_scroll_speed) * 150.0 * factor
 		else:
 			scroll_container.scroll_vertical = scroll_container.scroll_vertical
@@ -216,11 +222,11 @@ func _handle_auto_scroll(delta):
 		var left = scroll_g_rect.position.x + (scroll_g_rect.size.x * auto_scroll_range)
 		var right = scroll_g_rect.position.x + (scroll_g_rect.size.x * (1.0 - auto_scroll_range))
 
-		if left > mouse_g_pos.x:
-			var factor = (left - mouse_g_pos.x) / (left - scroll_g_rect.position.x)
+		if left > _global_mouse_pos.x:
+			var factor = (left - _global_mouse_pos.x) / (left - scroll_g_rect.position.x)
 			scroll_container.scroll_horizontal -= delta * float(auto_scroll_speed) * 150.0 * factor
-		elif right < mouse_g_pos.x:
-			var factor = (mouse_g_pos.x - right) / (scroll_g_rect.end.x - right)
+		elif right < _global_mouse_pos.x:
+			var factor = (_global_mouse_pos.x - right) / (scroll_g_rect.end.x - right)
 			scroll_container.scroll_horizontal += delta * float(auto_scroll_speed) * 150.0 * factor
 		else:
 			scroll_container.scroll_horizontal = scroll_container.scroll_horizontal

--- a/plugins/touch/rust/src/grab_touch_device.rs
+++ b/plugins/touch/rust/src/grab_touch_device.rs
@@ -268,10 +268,10 @@ impl INode for GrabTouchDevice {
                     for ev in iterator {
                         match ev.destructure() {
                             EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_X, value) => {
-                                PARSE_EVENT!(self.parent.clone().unwrap(), "x_coord_event", value);
+                                PARSE_EVENT!(self.parent.clone().unwrap(), "abs_x_event", value);
                             }
                             EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_Y, value) => {
-                                PARSE_EVENT!(self.parent.clone().unwrap(), "y_coord_event", value);
+                                PARSE_EVENT!(self.parent.clone().unwrap(), "abs_y_event", value);
                             }
                             EventSummary::Key(_, KeyCode::BTN_TOUCH, value) => {
                                 PARSE_EVENT!(self.parent.clone().unwrap(), "key_event", value);

--- a/plugins/touch/scripts/touch_controller.gd
+++ b/plugins/touch/scripts/touch_controller.gd
@@ -1,150 +1,174 @@
 class_name TouchController
 extends PluginControllerBase
+## Controller for handling touch devices.
+##
+## Provides functions to control touch devices and process the picked devices
+## events into touch events.
+## NOTE: It can't modify mouse position, so [code]get_local_mouse_position()[/code]
+## and [code]get_global_mouse_position()[/code] should be avoided everywhere.
 
 const PLUGIN_NAME = "Touch"
 
-# Vars
-var x_changed: bool = false
-var y_changed: bool = false
-var event_lmb = InputEventMouseButton.new()
-var in_focus: bool = true
-var current_screen_size: Vector2
-var device_max_abs_x: int = 0
-var device_max_abs_y: int = 0
-var divide_x_by: float = 0.0
-var divide_y_by: float = 0.0
-
-# Nodes
-var grab_touch_devices_script
-
-# Non fullscreen functions
-var window_area_min: Vector2 = Vector2(0, 0)
-var window_area_max: Vector2 = Vector2(0, 0)
-
-var _default_device: String
+var _grab_touch_devices_script: GrabTouchDevice = null # Touch device grabber.
+var _x_coord: float = -1 # Absolute X coordinate.
+var _y_coord: float = -1 # Absolute Y coordinate.
+var _x_diff: float = 0 # X coordinate delta to previous.
+var _y_diff: float = 0 # Y coordinate delta to previous.
+var _pressed: bool = false # Touch down state.
+var _device_max_abs_x: int = 0 # Device's maximum value for ABS_X events.
+var _device_max_abs_y: int = 0 # Device's maximum value for ABS_X events.
+var _divide_x_by: float = 0.0 # Amount to divide X by based on screen size and device's max values.
+var _divide_y_by: float = 0.0 # Amount to divide Y by based on screen size and device's max values.
+var _window_area_min: Vector2 = Vector2(0, 0) # Top left position of window in current screen.
+var _window_area_max: Vector2 = Vector2(0, 0) # Bottom right position of window in current screen.
+var _default_device: String # Default device string.
+var _debug_cursor: ColorRect = null # Debug cursor instance. Will only be set if in editor.
 
 
-func _init():
+func _init() -> void:
 	config.add_string("Default Device", "default_device", "")
 	plugin_name = PLUGIN_NAME
 
-	# FIXME config label migration, delete in the future
-	GlobalSignals.connect("exited_edit_mode", _on_exited_edit_mode)
 
+func _ready() -> void:
+	super()
 
-func _ready():
-	grab_touch_devices_script = GrabTouchDevice.new()
-	add_child(grab_touch_devices_script)
+	_grab_touch_devices_script = GrabTouchDevice.new()
+	add_child(_grab_touch_devices_script)
 
 	get_tree().get_root().connect("size_changed", _on_main_window_resized)
 	# Need to trigger it once on ready to populate values on startup
 	_on_main_window_resized()
 
-	# Set event_lmb to left mouse button
-	event_lmb.button_index = 1
-
-	# Because this requires device_options and thus needs to be _ready() we call handle_config
-	# here manually
-	handle_config()
-
 	if OS.has_feature("editor"):
-		var debug_cursor: ColorRect = get_node_or_null("/root/Main/DebugCursor")
-		if debug_cursor:
-			debug_cursor.visible = true
+		_debug_cursor = get_node_or_null("/root/Main/DebugCursor")
+		if _debug_cursor:
+			_debug_cursor.visible = true
 
 
-func _on_main_window_resized():
-	current_screen_size = DisplayServer.screen_get_size()
-	calculate_divide_by()
-	if not ((get_window().mode == Window.MODE_EXCLUSIVE_FULLSCREEN) or (get_window().mode == Window.MODE_FULLSCREEN)):
-		calculate_window_area()
-
-
-func handle_config():
-	var data = config.get_as_dict()
+## Overwritten to handle config values.
+func handle_config() -> void:
+	var data: Dictionary = config.get_as_dict()
 
 	_default_device = data["default_device"]
 
 
+## Get default device set by config.
 func get_default_device() -> String:
 	return _default_device
 
 
-func calculate_window_area():
-	window_area_min = get_window().get_position() - DisplayServer.screen_get_position()
-	window_area_max = get_window().get_position() + get_window().get_size() - DisplayServer.screen_get_position()
+## Try to reconnect current device.
+func reconnect_device() -> void:
+	_grab_touch_devices_script.call("reconnect_device")
 
 
-func reconnect_device():
-	grab_touch_devices_script.call("reconnect_device")
+## Get all allowed/touch devices.
+func get_devices() -> PackedStringArray:
+	return _grab_touch_devices_script.call("get_devices")
 
 
-func get_devices():
-	return grab_touch_devices_script.call("get_devices")
-
-
-func grab_device():
-	var ret = grab_touch_devices_script.call("grab_device")
+## Grabs current device.
+func grab_device() -> void:
+	var ret: Variant = _grab_touch_devices_script.call("grab_device")
 	if typeof(ret) == TYPE_STRING:
 		push_warning("Failed grabbing device: " + ret)
 
 
-func ungrab_device():
-	grab_touch_devices_script.call("ungrab_device")
+## Ungrabs current device.
+func ungrab_device() -> void:
+	_grab_touch_devices_script.call("ungrab_device")
 
 
-func set_device(device_name):
-	var ret = grab_touch_devices_script.call("set_device", device_name)
+## Tries to set device to [param device_name].[br]
+## NOTE: Also tries to grab new device immediately.
+func set_device(device_name: String) -> void:
+	var ret: Variant = _grab_touch_devices_script.call("set_device", device_name)
 	if typeof(ret) == TYPE_STRING:
 		push_warning("Failed setting device: " + ret)
+		return
 	grab_device()
-	device_max_abs_x = grab_touch_devices_script.call("get_device_max_abs_x")
-	device_max_abs_y = grab_touch_devices_script.call("get_device_max_abs_y")
-	calculate_divide_by()
+	_device_max_abs_x = _grab_touch_devices_script.call("get_device_max_abs_x")
+	_device_max_abs_y = _grab_touch_devices_script.call("get_device_max_abs_y")
+	_calculate_divide_by()
 
 
-func calculate_divide_by():
-	divide_x_by = device_max_abs_x / current_screen_size.x
-	divide_y_by = device_max_abs_y / current_screen_size.y
+## Function for [GrabTouchDevice] when a ABS_X event was registered.
+func abs_x_event(new_x: int) -> void:
+	if _x_coord > -1:
+		_x_diff = (new_x / _divide_x_by) - _x_coord
+
+	_x_coord = new_x / _divide_x_by
+	_handle_event()
 
 
-func x_coord_event(new_x):
-	event_lmb.position.x = new_x / divide_x_by
-	x_changed = true
-	handle_event()
+## Function for [GrabTouchDevice] when a ABS_Y event was registered.
+func abs_y_event(new_y: int) -> void:
+	if _y_coord > -1:
+		_y_diff = (new_y / _divide_y_by) - _y_coord
+
+	_y_coord = new_y / _divide_y_by
+	_handle_event()
 
 
-func y_coord_event(new_y):
-	event_lmb.position.y = new_y / divide_y_by
-	y_changed = true
-	handle_event()
+## Function for [GrabTouchDevice] when a key was pressed (touch down or up in this case).
+func key_event(state: bool) -> void:
+	_pressed = state
+	_handle_event()
 
 
-func key_event(state):
-	event_lmb.pressed = state
-	x_changed = false
-	y_changed = false
-	handle_event()
-
-
-func handle_event():
+# Send touch device events to global [Input] if all necessary conditions are met.
+func _handle_event() -> void:
 	# This check is necessary because the button down event is the first event
 	# if we don't first set x and y it will use the previous position
-	if !event_lmb.pressed or (x_changed and y_changed):
+	if _x_coord > -1 and _y_coord > -1:
 		# If window is not fullscreen we have to calculate if the touch was within the area of the window
 		# If it wasn't we skip the event
-		if (not ((get_window().mode == Window.MODE_EXCLUSIVE_FULLSCREEN) or (get_window().mode == Window.MODE_FULLSCREEN))) and \
-			((event_lmb.position.x > window_area_max.x or event_lmb.position.x < window_area_min.x) or \
-			 (event_lmb.position.y > window_area_max.y or event_lmb.position.y < window_area_min.y)):
+		if _pressed and (not ((get_window().mode == Window.MODE_EXCLUSIVE_FULLSCREEN) or (get_window().mode == Window.MODE_FULLSCREEN))) and \
+				((_x_coord > _window_area_max.x or _x_coord < _window_area_min.x) or \
+				 (_y_coord > _window_area_max.y or _y_coord < _window_area_min.y)):
 			return
 
-		# We can't modify event_lmb directly as this would also alter future events
-		var mod_event = event_lmb.duplicate()
-		mod_event.position -= window_area_min
-		Input.parse_input_event(mod_event)
-		if OS.has_feature("editor"):
-			get_node("/root/Main/DebugCursor").position = mod_event.position
+		Input.parse_input_event(_construct_touch_event())
 
 
-func _on_exited_edit_mode() -> void:
-	config.save()
+func _construct_touch_event() -> InputEvent:
+	var event: InputEvent
+	if not _pressed or _x_diff == 0 and _y_diff == 0:
+		event = InputEventScreenTouch.new()
+		event.pressed = _pressed
+	else:
+		event = InputEventScreenDrag.new()
+		event.relative = Vector2(_x_diff, _y_diff)
+		_x_diff = 0
+		_y_diff = 0
+
+	event.position = Vector2(_x_coord, _y_coord) - _window_area_min
+	if _debug_cursor:
+		_debug_cursor.position = event.position
+
+	if not _pressed:
+		_x_coord = -1
+		_y_coord = -1
+		_x_diff = 0
+		_y_diff = 0
+
+	return event
+
+
+# Calculates [member _divide_x_by] and [member _divide_y_by].
+func _calculate_divide_by() -> void:
+	_divide_x_by = _device_max_abs_x / float(DisplayServer.screen_get_size().x)
+	_divide_y_by = _device_max_abs_y / float(DisplayServer.screen_get_size().y)
+
+
+# Calculates [member _window_area_min] and [member _window_area_max].
+func _calculate_window_area() -> void:
+	_window_area_min = get_window().get_position() - DisplayServer.screen_get_position()
+	_window_area_max = get_window().get_position() + get_window().get_size() - DisplayServer.screen_get_position()
+
+
+func _on_main_window_resized() -> void:
+	_calculate_divide_by()
+	if not ((get_window().mode == Window.MODE_EXCLUSIVE_FULLSCREEN) or (get_window().mode == Window.MODE_FULLSCREEN)):
+		_calculate_window_area()


### PR DESCRIPTION
Previously it would always use absolute mouse events which works fine for just clicking, however dragging anything does not work this way.
Now it issues relative/drag events after the initial click.

Fixes #35 